### PR TITLE
Telegram mini app client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Copy this file to .env and fill in local/private values.
+# Never commit .env.
+
+TELEGRAM_BOT_TOKEN=123456:replace-with-botfather-token
+TELEGRAM_WEBHOOK_SECRET=replace-with-random-secret
+TELEGRAM_BOT_USERNAME=replace_with_bot_username_without_at
+PUBLIC_BASE_URL=https://replace-with-your-public-https-url

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 redis-data/
 __pycache__/
 .DS_Store
+
+# Local secrets/config
+.env
+.env.*
+!.env.example

--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ The API currently supports:
   - create users, groups, and expenses from the browser
   - view users, groups, expenses, and settlements
 
+- `telegram client`
+  - serve a Telegram Mini App at `/telegram/`
+  - validate Telegram Mini App init data server-side
+  - map Telegram users to ChipIn users
+  - link Telegram group chats to ChipIn groups
+  - let authenticated Telegram users view their groups and add expenses
+  - receive bot updates at `/telegram/webhook/`
+
 ## Tech Stack
 
 - Python
@@ -74,9 +82,45 @@ docker compose up --build
 From there, the main places to look are:
 
 - `http://localhost/admin/` for the admin panel
+- `http://localhost/telegram/` for the Telegram Mini App web client
 - [docs/COMMANDS.md](docs/COMMANDS.md) for example API usage with `curl`
 - [docs/GET_STARTED_REDIS-STACK.md](docs/GET_STARTED_REDIS-STACK.md) for Redis Stack notes and CLI-oriented indexing examples
 - [docs/APP_STRUCTURE.md](docs/APP_STRUCTURE.md) for the current repository layout
+
+## Telegram Client Setup
+
+The Telegram client uses ChipIn as the centralized data store. Telegram provides user/chat identity and the Mini App surface, but expenses, groups, users, and settlements stay in Redis through the existing backend.
+
+Configure these environment variables before using the bot integration:
+
+```bash
+cp .env.example .env
+```
+
+Then edit `.env`:
+
+```bash
+TELEGRAM_BOT_TOKEN=123456:your-bot-token
+TELEGRAM_WEBHOOK_SECRET=your-random-webhook-secret
+TELEGRAM_BOT_USERNAME=your_bot_username
+PUBLIC_BASE_URL=https://your-public-chipin-host
+```
+
+`TELEGRAM_BOT_TOKEN` comes from BotFather. `TELEGRAM_BOT_USERNAME` is the bot username you chose in BotFather, without the leading `@`. `TELEGRAM_WEBHOOK_SECRET` is a random string you create yourself, for example with `openssl rand -hex 32`. `PUBLIC_BASE_URL` is the public HTTPS URL where Telegram can reach this app, such as an ngrok/cloudflared URL or the deployed production URL.
+
+Then configure the bot with BotFather and set the webhook to:
+
+```text
+https://your-public-chipin-host/telegram/webhook/
+```
+
+Use the same `TELEGRAM_WEBHOOK_SECRET` as Telegram's webhook secret token. The Mini App URL is:
+
+```text
+https://your-public-chipin-host/telegram/
+```
+
+In a Telegram group, send `/chipin` or `/chipin@your_bot_username`. Telegram only allows Mini App `web_app` buttons in private chats, so the group response links users to the bot's private chat first. From there, the bot opens the Mini App for the linked ChipIn group.
 
 ## Repository Overview
 
@@ -103,6 +147,7 @@ Key areas:
 - [app/models/](app/models): domain objects and settlement calculation logic
 - [app/services/redis_service.py](app/services/redis_service.py): Redis access layer and search/query helpers
 - [app/static/admin/](app/static/admin): admin panel served at `/admin/`
+- [app/static/telegram/](app/static/telegram): Telegram Mini App client served at `/telegram/`
 - [app/tests/](app/tests): route-level tests with a mocked Redis service
 
 ## Where To Look First
@@ -119,6 +164,7 @@ If you are visiting the repository for the first time:
 - The app is designed to run with Redis Stack and relies on RedisJSON and RediSearch features.
 - The Docker setup defines separate `app` and `redis` services in [docker-compose.yml](docker-compose.yml).
 - The admin panel is served by Flask at `/admin/` and calls the existing JSON routes directly.
+- The Telegram Mini App is served by Flask at `/telegram/` and uses Telegram `initData` for user authentication.
 - Tests are written with pytest and use a mocked in-memory Redis service instead of requiring a real Redis instance for test execution.
 - Some detailed Redis CLI examples in [docs/GET_STARTED_REDIS-STACK.md](docs/GET_STARTED_REDIS-STACK.md) describe the underlying data ideas, but the application code is the source of truth for the current API field names and route behavior.
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,15 @@ Then configure the bot with BotFather and set the webhook to:
 https://your-public-chipin-host/telegram/webhook/
 ```
 
-Use the same `TELEGRAM_WEBHOOK_SECRET` as Telegram's webhook secret token. The Mini App URL is:
+Use the same `TELEGRAM_WEBHOOK_SECRET` as Telegram's webhook secret token:
+
+```bash
+curl "https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/setWebhook" \
+  -d "url=$PUBLIC_BASE_URL/telegram/webhook/" \
+  -d "secret_token=$TELEGRAM_WEBHOOK_SECRET"
+```
+
+The Mini App URL is:
 
 ```text
 https://your-public-chipin-host/telegram/

--- a/app/main.py
+++ b/app/main.py
@@ -11,6 +11,7 @@ from routes.users import users_bp
 from routes.groups import groups_bp
 from routes.expenses import expenses_bp
 from routes.settlements import settlements_bp
+from routes.telegram import telegram_bp
 
 
 app = Flask(__name__)
@@ -20,6 +21,7 @@ app.register_blueprint(users_bp)
 app.register_blueprint(groups_bp)
 app.register_blueprint(expenses_bp)
 app.register_blueprint(settlements_bp)
+app.register_blueprint(telegram_bp)
 
 # Redis connection
 redis_client = redis.Redis(
@@ -43,6 +45,8 @@ def home():
                 "expenses": "/expenses",
                 "settlements": "/settlements",
                 "admin": "/admin/",
+                "telegram_client": "/telegram/",
+                "telegram_webhook": "/telegram/webhook/",
             },
         }
     )

--- a/app/routes/telegram.py
+++ b/app/routes/telegram.py
@@ -1,5 +1,6 @@
 import html
 import os
+from datetime import datetime
 from typing import Any
 from urllib.parse import urlencode
 
@@ -164,6 +165,162 @@ def create_telegram_expense():
     ), 201
 
 
+@telegram_bp.route("/api/expenses/<expense_id>/", methods=["PUT"])
+def update_telegram_expense(expense_id):
+    launch, error_response = _require_telegram_user()
+    if error_response:
+        return error_response
+
+    data = request.get_json(silent=True)
+    if not data:
+        return jsonify({"error": "Invalid request: invalid JSON"}), 400
+
+    expense = redis_service.get_expense(expense_id)
+    if not expense:
+        return jsonify({"error": "Expense not found"}), 404
+
+    group, error_response = _expense_access_group(
+        launch.user,
+        expense,
+        require_payer=True,
+    )
+    if error_response:
+        return error_response
+
+    if "name" in data:
+        expense_name = str(data["name"]).strip()
+        if not expense_name:
+            return jsonify({"error": "Expense name is required"}), 400
+        expense["name"] = expense_name
+
+    if "amount" in data:
+        try:
+            amount = float(data["amount"])
+        except (TypeError, ValueError):
+            return jsonify({"error": "Amount must be a number"}), 400
+        if amount <= 0:
+            return jsonify({"error": "Amount must be greater than zero"}), 400
+        expense["amount"] = amount
+
+    if "sharers" in data:
+        group_users = group.get("users") or []
+        sharers = data.get("sharers")
+        if not isinstance(sharers, list) or not sharers:
+            return jsonify({"error": "Sharers must be a non-empty list"}), 400
+        for name in sharers:
+            if name not in group_users:
+                return jsonify({"error": "One or more sharers are not in this group"}), 404
+        expense["sharers"] = sharers
+
+    expense["updated_at"] = _now_iso()
+    saved_expense = redis_service.save_expense(expense)
+    settlements = _save_recomputed_group_settlements(group)
+
+    return jsonify(
+        {
+            "saved_expense": saved_expense,
+            "group_settlement": _named_settlements(
+                settlements,
+                group.get("users") or [],
+            ),
+            "detail": _group_detail_payload(group),
+        }
+    ), 200
+
+
+@telegram_bp.route("/api/expenses/<expense_id>/", methods=["DELETE"])
+def delete_telegram_expense(expense_id):
+    launch, error_response = _require_telegram_user()
+    if error_response:
+        return error_response
+
+    expense = redis_service.get_expense(expense_id)
+    if not expense:
+        return jsonify({"error": "Expense not found"}), 404
+
+    group, error_response = _expense_access_group(
+        launch.user,
+        expense,
+        require_payer=True,
+    )
+    if error_response:
+        return error_response
+
+    redis_service.delete_expense_record(expense_id)
+    settlements = _save_recomputed_group_settlements(group)
+
+    return jsonify(
+        {
+            "message": f"Expense {expense_id} deleted successfully",
+            "group_settlement": _named_settlements(
+                settlements,
+                group.get("users") or [],
+            ),
+            "detail": _group_detail_payload(group),
+        }
+    ), 200
+
+
+@telegram_bp.route("/api/groups/<group_id>/settlements/paid/", methods=["POST"])
+def mark_telegram_settlement_paid(group_id):
+    launch, error_response = _require_telegram_user()
+    if error_response:
+        return error_response
+
+    group = redis_service.get_group(group_id)
+    if not group:
+        return jsonify({"error": "Group not found"}), 404
+
+    group_users = group.get("users") or []
+    if launch.user["name"] not in group_users:
+        return jsonify({"error": "You are not a member of this group"}), 403
+
+    data = request.get_json(silent=True) or {}
+    for field in ["debtor", "creditor", "amount"]:
+        if field not in data:
+            return jsonify({"error": f"Invalid request: missing {field}"}), 400
+
+    debtor = data["debtor"]
+    creditor = data["creditor"]
+    if debtor not in group_users or creditor not in group_users:
+        return jsonify({"error": "Settlement users must be group members"}), 400
+
+    if launch.user["name"] not in {debtor, creditor}:
+        return jsonify({"error": "Only settlement participants can mark it paid"}), 403
+
+    try:
+        amount = float(data["amount"])
+    except (TypeError, ValueError):
+        return jsonify({"error": "Amount must be a number"}), 400
+    if amount <= 0:
+        return jsonify({"error": "Amount must be greater than zero"}), 400
+
+    open_amount = _open_settlement_amount(group, debtor, creditor)
+    if open_amount is None:
+        return jsonify({"error": "Settlement is not open"}), 400
+    if amount - open_amount > 0.005:
+        return jsonify({"error": "Payment amount exceeds the open settlement"}), 400
+
+    payment = redis_service.save_settlement_payment(
+        group_id,
+        {
+            "debtor": debtor,
+            "creditor": creditor,
+            "amount": amount,
+            "recorded_by": launch.user["name"],
+        },
+    )
+    settlements = _save_recomputed_group_settlements(group)
+
+    return jsonify(
+        {
+            "payment": payment,
+            "group_settlement": _named_settlements(settlements, group_users),
+            "detail": _group_detail_payload(group),
+        }
+    ), 201
+
+
 @telegram_bp.route("/api/settlements/", methods=["GET"])
 def get_my_settlements():
     launch, error_response = _require_telegram_user()
@@ -256,6 +413,7 @@ def _group_payload(group: dict[str, Any] | None) -> dict[str, Any] | None:
         "telegram_chat_id": group.get("telegram_chat_id"),
         "telegram_chat_title": group.get("telegram_chat_title"),
         "telegram_chat_type": group.get("telegram_chat_type"),
+        "private_chat_url": _private_chat_url(group.get("id")),
         "expenses_count": len(expenses),
         "created_at": group.get("created_at"),
     }
@@ -263,15 +421,14 @@ def _group_payload(group: dict[str, Any] | None) -> dict[str, Any] | None:
 
 def _group_detail_payload(group: dict[str, Any]) -> dict[str, Any]:
     expenses = redis_service.get_group_expenses(group["id"])
-    settlements = redis_service.get_group_settlements(group["id"]) or []
-
-    if not settlements and expenses:
-        settlements = Settlement(expenses, group.get("users") or [])
+    settlements = _calculate_group_settlements(group)
+    payments = redis_service.get_group_settlement_payments(group["id"])
 
     return {
         "group": _group_payload(group),
         "expenses": expenses,
         "settlements": _named_settlements(settlements, group.get("users") or []),
+        "payment_history": payments,
     }
 
 
@@ -287,23 +444,114 @@ def _public_user(user: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _save_updated_group_settlements(group: dict[str, Any], expense: Expense) -> list[list]:
-    group_users = group.get("users") or []
-    tx_prev = redis_service.get_group_settlements(group["id"])
+def _save_updated_group_settlements(
+    group: dict[str, Any],
+    _expense: Expense,
+) -> list[list]:
+    return _save_recomputed_group_settlements(group)
 
-    tx_hist: list[tuple] | None = None
-    if tx_prev is not None:
-        tx_hist = [tuple(x) for x in tx_prev]
 
-    if tx_hist is None:
-        group_expenses = redis_service.get_group_expenses(group["id"])
-        tx = Settlement(group_expenses, group_users)
-    else:
-        tx = Settlement([expense.to_dict()], group_users, tx_hist)
-
-    tx_json = [list(t) for t in tx]
+def _save_recomputed_group_settlements(group: dict[str, Any]) -> list[list]:
+    tx_json = _calculate_group_settlements(group)
     redis_service.save_group_settlements(tx_json, f"settlement-group:{group['id']}")
     return tx_json
+
+
+def _calculate_group_settlements(group: dict[str, Any]) -> list[list]:
+    group_users = group.get("users") or []
+    group_expenses = redis_service.get_group_expenses(group["id"])
+    if not group_expenses or not group_users:
+        return []
+
+    base_settlements = Settlement(group_expenses, group_users)
+    balances = [0.0 for _ in group_users]
+
+    for debtor_idx, creditor_idx, amount in base_settlements:
+        balances[int(debtor_idx)] -= float(amount)
+        balances[int(creditor_idx)] += float(amount)
+
+    user_indexes = {name: idx for idx, name in enumerate(group_users)}
+    for payment in redis_service.get_group_settlement_payments(group["id"]):
+        debtor_idx = user_indexes.get(payment.get("debtor"))
+        creditor_idx = user_indexes.get(payment.get("creditor"))
+        if debtor_idx is None or creditor_idx is None:
+            continue
+
+        amount = float(payment.get("amount") or 0)
+        balances[debtor_idx] += amount
+        balances[creditor_idx] -= amount
+
+    return _settlements_from_balances(balances)
+
+
+def _settlements_from_balances(balances: list[float]) -> list[list]:
+    debtors = [
+        (idx, -balance)
+        for idx, balance in enumerate(balances)
+        if balance < -0.005
+    ]
+    creditors = [
+        (idx, balance)
+        for idx, balance in enumerate(balances)
+        if balance > 0.005
+    ]
+
+    settlements = []
+    debtor_idx = creditor_idx = 0
+
+    while debtor_idx < len(debtors) and creditor_idx < len(creditors):
+        debtor_user_idx, debtor_amount = debtors[debtor_idx]
+        creditor_user_idx, creditor_amount = creditors[creditor_idx]
+
+        amount = min(debtor_amount, creditor_amount)
+        settlements.append([debtor_user_idx, creditor_user_idx, amount])
+
+        debtor_amount -= amount
+        creditor_amount -= amount
+
+        if debtor_amount <= 0.005:
+            debtor_idx += 1
+        else:
+            debtors[debtor_idx] = (debtor_user_idx, debtor_amount)
+
+        if creditor_amount <= 0.005:
+            creditor_idx += 1
+        else:
+            creditors[creditor_idx] = (creditor_user_idx, creditor_amount)
+
+    return settlements
+
+
+def _expense_access_group(
+    user: dict[str, Any],
+    expense: dict[str, Any],
+    require_payer: bool = False,
+):
+    group = redis_service.get_group_by_name(expense.get("group", ""))
+    if not group:
+        return None, (jsonify({"error": "Group not found"}), 404)
+
+    group_users = group.get("users") or []
+    if user["name"] not in group_users:
+        return None, (jsonify({"error": "You are not a member of this group"}), 403)
+
+    if require_payer and expense.get("payer") != user["name"]:
+        return None, (jsonify({"error": "Only the payer can change this expense"}), 403)
+
+    return group, None
+
+
+def _open_settlement_amount(
+    group: dict[str, Any], debtor: str, creditor: str
+) -> float | None:
+    users = group.get("users") or []
+    for open_debtor, open_creditor, amount in _named_settlements(
+        _calculate_group_settlements(group),
+        users,
+    ):
+        if open_debtor == debtor and open_creditor == creditor:
+            return float(amount)
+    return None
 
 
 def _named_settlements(settlements: list, users: list[str]) -> list[list]:
@@ -571,6 +819,10 @@ def _format_expense_notification(group: dict[str, Any], expense: dict[str, Any])
 
 def _format_money(amount: Any) -> str:
     return f"${float(amount or 0):.2f}"
+
+
+def _now_iso() -> str:
+    return datetime.now().isoformat()
 
 
 def _join_start_payload_group(payload: str, user: dict[str, Any] | None) -> dict[str, Any] | None:

--- a/app/routes/telegram.py
+++ b/app/routes/telegram.py
@@ -153,6 +153,7 @@ def create_telegram_expense():
     )
     saved_expense = redis_service.save_expense(expense.to_dict())
     settlements = _save_updated_group_settlements(group, expense)
+    _notify_telegram_group_expense(group, saved_expense)
 
     return jsonify(
         {
@@ -383,23 +384,38 @@ def _handle_bot_update(update: dict[str, Any]) -> None:
         if user:
             group = redis_service.add_user_to_group(group["id"], user["name"])
 
-    if command == "/balance" and user:
-        if _is_group_chat(chat):
-            telegram_bot_client.send_message(
-                chat["id"],
-                "Open ChipIn privately to view your balance.",
-                _private_chat_reply_markup(group["id"] if group else None),
-            )
-            return
+    if command == "/help":
+        _send_help_message(chat, group)
+        return
 
-        telegram_bot_client.send_message(
-            chat["id"],
+    if command == "/groups" and user:
+        _send_private_only_command(
+            chat,
+            group,
+            _format_groups_message(user),
+            _mini_app_reply_markup(),
+        )
+        return
+
+    if command == "/balance" and user:
+        _send_private_only_command(
+            chat,
+            group,
             _format_balance_message(user),
             _mini_app_reply_markup(group["id"] if group else None),
         )
         return
 
-    if command in {"/start", "/chipin", "/help"}:
+    if command == "/settlements" and user:
+        _send_private_only_command(
+            chat,
+            group,
+            _format_settlements_message(user),
+            _mini_app_reply_markup(group["id"] if group else None),
+        )
+        return
+
+    if command in {"/start", "/chipin"}:
         if _is_group_chat(chat):
             group_name = html.escape(group["name"] if group else chat.get("title", "this group"))
             text = (
@@ -441,6 +457,58 @@ def _handle_chat_membership_update(update: dict[str, Any]) -> None:
         redis_service.ensure_telegram_group(chat)
 
 
+def _notify_telegram_group_expense(group: dict[str, Any], expense: dict[str, Any]) -> None:
+    telegram_chat_id = group.get("telegram_chat_id")
+    if not telegram_chat_id:
+        return
+
+    telegram_bot_client.send_message(
+        telegram_chat_id,
+        _format_expense_notification(group, expense),
+        _private_chat_reply_markup(group["id"]),
+    )
+
+
+def _send_help_message(chat: dict[str, Any], group: dict[str, Any] | None) -> None:
+    if _is_group_chat(chat):
+        text = (
+            "ChipIn commands in this group:\n"
+            "/chipin - link this Telegram group to ChipIn\n"
+            "/balance - open private balance view\n"
+            "/help - show this help"
+        )
+        reply_markup = _private_chat_reply_markup(group["id"] if group else None)
+    else:
+        text = (
+            "ChipIn commands:\n"
+            "/start - open the Mini App\n"
+            "/groups - list your groups\n"
+            "/balance - show your aggregate balance\n"
+            "/settlements - show open settlements\n"
+            "/help - show this help"
+        )
+        reply_markup = _mini_app_reply_markup(group["id"] if group else None)
+
+    telegram_bot_client.send_message(chat["id"], text, reply_markup)
+
+
+def _send_private_only_command(
+    chat: dict[str, Any],
+    group: dict[str, Any] | None,
+    private_text: str,
+    private_reply_markup: dict[str, Any] | None,
+) -> None:
+    if _is_group_chat(chat):
+        telegram_bot_client.send_message(
+            chat["id"],
+            "Open ChipIn privately to view that.",
+            _private_chat_reply_markup(group["id"] if group else None),
+        )
+        return
+
+    telegram_bot_client.send_message(chat["id"], private_text, private_reply_markup)
+
+
 def _format_balance_message(user: dict[str, Any]) -> str:
     settlements = _user_settlements_payload(user)["aggregate"]
     if not settlements:
@@ -455,6 +523,54 @@ def _format_balance_message(user: dict[str, Any]) -> str:
         else:
             lines.append(f"You owe {other_user} {amount}")
     return "\n".join(lines)
+
+
+def _format_groups_message(user: dict[str, Any]) -> str:
+    groups = redis_service.get_groups_for_user(user["name"])
+    if not groups:
+        return "You are not in any ChipIn groups yet."
+
+    lines = ["Your ChipIn groups:"]
+    for group in groups:
+        member_count = len(group.get("users") or [])
+        expense_count = len(redis_service.get_group_expenses(group["id"]))
+        lines.append(
+            f"- {html.escape(group['name'])}: {member_count} users, {expense_count} expenses"
+        )
+    return "\n".join(lines)
+
+
+def _format_settlements_message(user: dict[str, Any]) -> str:
+    settlements_payload = _user_settlements_payload(user)
+    if not settlements_payload["groups"]:
+        return "You have no open ChipIn settlements."
+
+    lines = ["Your open settlements:"]
+    for group in settlements_payload["groups"]:
+        lines.append(f"\n{html.escape(group['group_name'])}:")
+        for debtor, creditor, amount in group["settlements"]:
+            lines.append(
+                f"- {html.escape(debtor)} pays {html.escape(creditor)} {_format_money(amount)}"
+            )
+
+    return "\n".join(lines)
+
+
+def _format_expense_notification(group: dict[str, Any], expense: dict[str, Any]) -> str:
+    payer = html.escape(expense.get("payer", "Someone"))
+    name = html.escape(expense.get("name", "an expense"))
+    group_name = html.escape(group.get("name", "this group"))
+    amount = _format_money(expense.get("amount", 0))
+    sharers_count = len(expense.get("sharers") or [])
+
+    return (
+        f"{payer} added <b>{name}</b> for <b>{amount}</b> in <b>{group_name}</b>.\n"
+        f"Split with {sharers_count} users."
+    )
+
+
+def _format_money(amount: Any) -> str:
+    return f"${float(amount or 0):.2f}"
 
 
 def _join_start_payload_group(payload: str, user: dict[str, Any] | None) -> dict[str, Any] | None:

--- a/app/routes/telegram.py
+++ b/app/routes/telegram.py
@@ -1,0 +1,524 @@
+import html
+import os
+from typing import Any
+from urllib.parse import urlencode
+
+from flask import Blueprint, jsonify, request, send_from_directory
+
+from models.expense import Expense
+from models.settlement import Settlement
+from services.redis_service import redis_service
+from services.telegram_auth import TelegramAuthError, TelegramInitData, validate_init_data
+from services.telegram_bot import telegram_bot_client
+
+
+telegram_bp = Blueprint("telegram", __name__, url_prefix="/telegram")
+
+
+@telegram_bp.route("/")
+def telegram_client():
+    static_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "static", "telegram")
+    return send_from_directory(static_dir, "index.html")
+
+
+@telegram_bp.route("/auth/", methods=["POST"])
+def telegram_auth():
+    try:
+        init_data = _init_data_from_request_body()
+        launch = _authenticate_init_data(init_data)
+        launch_group = None
+
+        if _is_group_chat(launch.init_data.chat):
+            launch_group = redis_service.ensure_telegram_group(launch.init_data.chat)
+            launch_group = redis_service.add_user_to_group(launch_group["id"], launch.user["name"])
+
+        return jsonify(
+            {
+                "user": _public_user(launch.user),
+                "groups": _groups_payload(redis_service.get_groups_for_user(launch.user["name"])),
+                "launch_group": _group_payload(launch_group) if launch_group else None,
+                "settlements": _user_settlements_payload(launch.user),
+            }
+        ), 200
+    except TelegramAuthError as exc:
+        return _auth_error_response(exc)
+
+
+@telegram_bp.route("/api/groups/", methods=["GET"])
+def get_my_groups():
+    launch, error_response = _require_telegram_user()
+    if error_response:
+        return error_response
+
+    groups = redis_service.get_groups_for_user(launch.user["name"])
+    return jsonify({"groups": _groups_payload(groups)}), 200
+
+
+@telegram_bp.route("/api/groups/<group_id>/", methods=["GET"])
+def get_my_group(group_id):
+    launch, error_response = _require_telegram_user()
+    if error_response:
+        return error_response
+
+    group = redis_service.get_group(group_id)
+    if not group:
+        return jsonify({"error": "Group not found"}), 404
+    if launch.user["name"] not in (group.get("users") or []):
+        return jsonify({"error": "You are not a member of this group"}), 403
+
+    return jsonify(_group_detail_payload(group)), 200
+
+
+@telegram_bp.route("/api/groups/from-chat/", methods=["POST"])
+def create_group_from_chat():
+    launch, error_response = _require_telegram_user()
+    if error_response:
+        return error_response
+
+    data = request.get_json(silent=True) or {}
+    chat = data.get("chat") or launch.init_data.chat
+    if not _is_group_chat(chat):
+        return jsonify({"error": "Telegram group chat context is required"}), 400
+
+    group = redis_service.ensure_telegram_group(chat)
+    group = redis_service.add_user_to_group(group["id"], launch.user["name"])
+
+    return jsonify({"group": _group_payload(group)}), 201
+
+
+@telegram_bp.route("/api/groups/<group_id>/join/", methods=["POST"])
+def join_telegram_group(group_id):
+    launch, error_response = _require_telegram_user()
+    if error_response:
+        return error_response
+
+    group = redis_service.get_group(group_id)
+    if not group:
+        return jsonify({"error": "Group not found"}), 404
+    if group.get("source") != "telegram":
+        return jsonify({"error": "Only Telegram-backed groups support self-join"}), 400
+
+    group = redis_service.add_user_to_group(group_id, launch.user["name"])
+    return jsonify({"group": _group_payload(group)}), 200
+
+
+@telegram_bp.route("/api/expenses/", methods=["POST"])
+def create_telegram_expense():
+    launch, error_response = _require_telegram_user()
+    if error_response:
+        return error_response
+
+    data = request.get_json(silent=True)
+    if not data:
+        return jsonify({"error": "Invalid request: invalid JSON"}), 400
+
+    for field in ["group_id", "name", "amount"]:
+        if field not in data:
+            return jsonify({"error": f"Invalid request: missing {field}"}), 400
+
+    group = redis_service.get_group(data["group_id"])
+    if not group:
+        return jsonify({"error": "Group not found"}), 404
+
+    group_users = group.get("users") or []
+    payer = launch.user["name"]
+    if payer not in group_users:
+        return jsonify({"error": "You are not a member of this group"}), 403
+
+    try:
+        amount = float(data["amount"])
+    except (TypeError, ValueError):
+        return jsonify({"error": "Amount must be a number"}), 400
+
+    if amount <= 0:
+        return jsonify({"error": "Amount must be greater than zero"}), 400
+
+    sharers = data.get("sharers") or group_users
+    if not isinstance(sharers, list) or not sharers:
+        return jsonify({"error": "Sharers must be a non-empty list"}), 400
+    for name in sharers:
+        if name not in group_users:
+            return jsonify({"error": "One or more sharers are not in this group"}), 404
+
+    expense_name = str(data["name"]).strip()
+    if not expense_name:
+        return jsonify({"error": "Expense name is required"}), 400
+
+    expense = Expense(
+        name=expense_name,
+        group=group["name"],
+        amount=amount,
+        payer=payer,
+        sharers=sharers,
+    )
+    saved_expense = redis_service.save_expense(expense.to_dict())
+    settlements = _save_updated_group_settlements(group, expense)
+
+    return jsonify(
+        {
+            "saved_expense": saved_expense,
+            "group_settlement": _named_settlements(settlements, group_users),
+            "detail": _group_detail_payload(group),
+        }
+    ), 201
+
+
+@telegram_bp.route("/api/settlements/", methods=["GET"])
+def get_my_settlements():
+    launch, error_response = _require_telegram_user()
+    if error_response:
+        return error_response
+
+    return jsonify(_user_settlements_payload(launch.user)), 200
+
+
+@telegram_bp.route("/webhook/", methods=["POST"])
+def telegram_webhook():
+    if not _valid_webhook_secret():
+        return jsonify({"error": "Invalid Telegram webhook secret"}), 403
+
+    update = request.get_json(silent=True)
+    if not update:
+        return jsonify({"error": "Invalid Telegram update"}), 400
+
+    _handle_bot_update(update)
+    return jsonify({"ok": True}), 200
+
+
+class TelegramLaunch:
+    def __init__(self, init_data: TelegramInitData, user: dict[str, Any]):
+        self.init_data = init_data
+        self.user = user
+
+
+def _init_data_from_request_body() -> str:
+    data = request.get_json(silent=True) or {}
+    return data.get("init_data") or request.headers.get("X-Telegram-Init-Data", "")
+
+
+def _init_data_from_headers() -> str:
+    header_value = request.headers.get("X-Telegram-Init-Data")
+    if header_value:
+        return header_value
+
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header.startswith("Telegram "):
+        return auth_header[len("Telegram ") :]
+
+    return ""
+
+
+def _authenticate_init_data(init_data: str) -> TelegramLaunch:
+    bot_token = os.getenv("TELEGRAM_BOT_TOKEN", "")
+    parsed = validate_init_data(init_data, bot_token)
+    user = redis_service.upsert_telegram_user(parsed.user)
+    return TelegramLaunch(parsed, user)
+
+
+def _require_telegram_user():
+    try:
+        return _authenticate_init_data(_init_data_from_headers()), None
+    except TelegramAuthError as exc:
+        return None, _auth_error_response(exc)
+
+
+def _auth_error_response(exc: TelegramAuthError):
+    status = 503 if "not configured" in str(exc) else 401
+    return jsonify({"error": str(exc)}), status
+
+
+def _valid_webhook_secret() -> bool:
+    expected = os.getenv("TELEGRAM_WEBHOOK_SECRET", "")
+    if not expected:
+        return True
+    return request.headers.get("X-Telegram-Bot-Api-Secret-Token") == expected
+
+
+def _is_group_chat(chat: dict | None) -> bool:
+    return bool(chat and chat.get("type") in {"group", "supergroup"})
+
+
+def _groups_payload(groups: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [_group_payload(group) for group in groups]
+
+
+def _group_payload(group: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not group:
+        return None
+
+    expenses = redis_service.get_group_expenses(group["id"])
+    return {
+        "id": group.get("id"),
+        "name": group.get("name"),
+        "users": group.get("users") or [],
+        "source": group.get("source", "manual"),
+        "telegram_chat_id": group.get("telegram_chat_id"),
+        "telegram_chat_title": group.get("telegram_chat_title"),
+        "telegram_chat_type": group.get("telegram_chat_type"),
+        "expenses_count": len(expenses),
+        "created_at": group.get("created_at"),
+    }
+
+
+def _group_detail_payload(group: dict[str, Any]) -> dict[str, Any]:
+    expenses = redis_service.get_group_expenses(group["id"])
+    settlements = redis_service.get_group_settlements(group["id"]) or []
+
+    if not settlements and expenses:
+        settlements = Settlement(expenses, group.get("users") or [])
+
+    return {
+        "group": _group_payload(group),
+        "expenses": expenses,
+        "settlements": _named_settlements(settlements, group.get("users") or []),
+    }
+
+
+def _public_user(user: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": user.get("id"),
+        "name": user.get("name"),
+        "telegram_id": user.get("telegram_id"),
+        "telegram_username": user.get("telegram_username"),
+        "telegram_first_name": user.get("telegram_first_name"),
+        "telegram_last_name": user.get("telegram_last_name"),
+        "telegram_photo_url": user.get("telegram_photo_url"),
+    }
+
+
+def _save_updated_group_settlements(group: dict[str, Any], expense: Expense) -> list[list]:
+    group_users = group.get("users") or []
+    tx_prev = redis_service.get_group_settlements(group["id"])
+
+    tx_hist: list[tuple] | None = None
+    if tx_prev is not None:
+        tx_hist = [tuple(x) for x in tx_prev]
+
+    if tx_hist is None:
+        group_expenses = redis_service.get_group_expenses(group["id"])
+        tx = Settlement(group_expenses, group_users)
+    else:
+        tx = Settlement([expense.to_dict()], group_users, tx_hist)
+
+    tx_json = [list(t) for t in tx]
+    redis_service.save_group_settlements(tx_json, f"settlement-group:{group['id']}")
+    return tx_json
+
+
+def _named_settlements(settlements: list, users: list[str]) -> list[list]:
+    named = []
+    for debtor_idx, creditor_idx, amount in settlements:
+        debtor_idx = int(debtor_idx)
+        creditor_idx = int(creditor_idx)
+        if debtor_idx >= len(users) or creditor_idx >= len(users):
+            continue
+        named.append([users[debtor_idx], users[creditor_idx], float(amount)])
+    return named
+
+
+def _user_settlements_payload(user: dict[str, Any]) -> dict[str, Any]:
+    user_name = user["name"]
+    grouped = []
+    aggregate: dict[str, float] = {}
+
+    for group in redis_service.get_groups_for_user(user_name):
+        detail = _group_detail_payload(group)
+        user_settlements = []
+        for debtor, creditor, amount in detail["settlements"]:
+            amount = float(amount)
+            if debtor == user_name:
+                user_settlements.append([debtor, creditor, amount])
+                aggregate[creditor] = aggregate.get(creditor, 0) - amount
+            elif creditor == user_name:
+                user_settlements.append([debtor, creditor, amount])
+                aggregate[debtor] = aggregate.get(debtor, 0) + amount
+
+        if user_settlements:
+            grouped.append(
+                {
+                    "group_id": group["id"],
+                    "group_name": group["name"],
+                    "settlements": user_settlements,
+                }
+            )
+
+    return {
+        "aggregate": _aggregate_settlements_payload(aggregate),
+        "groups": grouped,
+    }
+
+
+def _aggregate_settlements_payload(aggregate: dict[str, float]) -> list[dict[str, Any]]:
+    rows = []
+    for name, balance in sorted(aggregate.items()):
+        if abs(balance) < 1e-9:
+            continue
+        rows.append(
+            {
+                "name": name,
+                "amount": abs(balance),
+                "direction": "owes_you" if balance > 0 else "you_owe",
+            }
+        )
+    return rows
+
+
+def _handle_bot_update(update: dict[str, Any]) -> None:
+    message = update.get("message") or update.get("edited_message")
+    if not message:
+        _handle_chat_membership_update(update)
+        return
+
+    chat = message.get("chat") or {}
+    sender = message.get("from") or {}
+    text = message.get("text") or ""
+    parts = text.split()
+    command = parts[0].split("@")[0].lower() if parts else ""
+    payload = parts[1] if len(parts) > 1 else ""
+
+    user = redis_service.upsert_telegram_user(sender) if sender.get("id") else None
+    group = None
+    if _is_group_chat(chat):
+        group = redis_service.ensure_telegram_group(chat)
+        if user:
+            group = redis_service.add_user_to_group(group["id"], user["name"])
+
+    if command == "/balance" and user:
+        if _is_group_chat(chat):
+            telegram_bot_client.send_message(
+                chat["id"],
+                "Open ChipIn privately to view your balance.",
+                _private_chat_reply_markup(group["id"] if group else None),
+            )
+            return
+
+        telegram_bot_client.send_message(
+            chat["id"],
+            _format_balance_message(user),
+            _mini_app_reply_markup(group["id"] if group else None),
+        )
+        return
+
+    if command in {"/start", "/chipin", "/help"}:
+        if _is_group_chat(chat):
+            group_name = html.escape(group["name"] if group else chat.get("title", "this group"))
+            text = (
+                f"ChipIn is ready for <b>{group_name}</b>. "
+                "Open the bot privately to add expenses."
+            )
+            reply_markup = _private_chat_reply_markup(group["id"] if group else None)
+        else:
+            linked_group = _join_start_payload_group(payload, user)
+            if linked_group:
+                group_name = html.escape(linked_group["name"])
+                text = f"You're linked to <b>{group_name}</b>. Open ChipIn to continue."
+                reply_markup = _mini_app_reply_markup(linked_group["id"])
+            elif payload.startswith("group_"):
+                text = "I could not find that ChipIn group. Send /chipin in the Telegram group again."
+                reply_markup = _mini_app_reply_markup()
+            else:
+                text = "Open ChipIn to see your groups, balances, expenses, and settlements."
+                reply_markup = _mini_app_reply_markup()
+
+        telegram_bot_client.send_message(
+            chat["id"],
+            text,
+            reply_markup,
+        )
+
+
+def _handle_chat_membership_update(update: dict[str, Any]) -> None:
+    membership = update.get("my_chat_member")
+    if not membership:
+        return
+
+    chat = membership.get("chat") or {}
+    if not _is_group_chat(chat):
+        return
+
+    new_status = (membership.get("new_chat_member") or {}).get("status")
+    if new_status in {"member", "administrator"}:
+        redis_service.ensure_telegram_group(chat)
+
+
+def _format_balance_message(user: dict[str, Any]) -> str:
+    settlements = _user_settlements_payload(user)["aggregate"]
+    if not settlements:
+        return "You have no open ChipIn settlements."
+
+    lines = ["Your ChipIn balance:"]
+    for row in settlements:
+        amount = f"${float(row['amount']):.2f}"
+        other_user = html.escape(row["name"])
+        if row["direction"] == "owes_you":
+            lines.append(f"{other_user} owes you {amount}")
+        else:
+            lines.append(f"You owe {other_user} {amount}")
+    return "\n".join(lines)
+
+
+def _join_start_payload_group(payload: str, user: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not user or not payload.startswith("group_"):
+        return None
+
+    group_id = payload[len("group_") :]
+    group = redis_service.get_group(group_id)
+    if not group or group.get("source") != "telegram":
+        return None
+
+    return redis_service.add_user_to_group(group_id, user["name"])
+
+
+def _private_chat_reply_markup(group_id: str | None = None) -> dict[str, Any] | None:
+    url = _private_chat_url(group_id)
+    if not url:
+        return None
+
+    return {
+        "inline_keyboard": [
+            [
+                {
+                    "text": "Open ChipIn",
+                    "url": url,
+                }
+            ]
+        ]
+    }
+
+
+def _private_chat_url(group_id: str | None = None) -> str | None:
+    bot_username = os.getenv("TELEGRAM_BOT_USERNAME", "").lstrip("@")
+    if not bot_username:
+        return None
+
+    base_url = f"https://t.me/{bot_username}"
+    if not group_id:
+        return base_url
+
+    return f"{base_url}?{urlencode({'start': f'group_{group_id}'})}"
+
+
+def _mini_app_reply_markup(group_id: str | None = None) -> dict[str, Any]:
+    return {
+        "inline_keyboard": [
+            [
+                {
+                    "text": "Open ChipIn",
+                    "web_app": {"url": _mini_app_url(group_id)},
+                }
+            ]
+        ]
+    }
+
+
+def _mini_app_url(group_id: str | None = None) -> str:
+    public_base_url = os.getenv("PUBLIC_BASE_URL")
+    if public_base_url:
+        base_url = f"{public_base_url.rstrip('/')}/telegram/"
+    else:
+        base_url = f"{request.host_url.rstrip('/')}/telegram/"
+
+    if not group_id:
+        return base_url
+
+    return f"{base_url}?{urlencode({'group_id': group_id})}"

--- a/app/routes/telegram.py
+++ b/app/routes/telegram.py
@@ -1,14 +1,25 @@
 import html
 import os
-from datetime import datetime
 from typing import Any
 from urllib.parse import urlencode
 
 from flask import Blueprint, jsonify, request, send_from_directory
 
-from models.expense import Expense
-from models.settlement import Settlement
+from services.expense_service import (
+    create_expense_for_user,
+    delete_expense_for_user,
+    expenses_with_permissions,
+    update_expense_for_user,
+)
 from services.redis_service import redis_service
+from services.service_errors import ServiceError
+from services.settlement_service import (
+    calculate_group_settlements,
+    mark_settlement_paid_for_user,
+    named_settlements,
+    settlements_with_permissions,
+    user_settlements_payload,
+)
 from services.telegram_auth import TelegramAuthError, TelegramInitData, validate_init_data
 from services.telegram_bot import telegram_bot_client
 
@@ -38,7 +49,7 @@ def telegram_auth():
                 "user": _public_user(launch.user),
                 "groups": _groups_payload(redis_service.get_groups_for_user(launch.user["name"])),
                 "launch_group": _group_payload(launch_group) if launch_group else None,
-                "settlements": _user_settlements_payload(launch.user),
+                "settlements": user_settlements_payload(launch.user),
             }
         ), 200
     except TelegramAuthError as exc:
@@ -67,7 +78,7 @@ def get_my_group(group_id):
     if launch.user["name"] not in (group.get("users") or []):
         return jsonify({"error": "You are not a member of this group"}), 403
 
-    return jsonify(_group_detail_payload(group)), 200
+    return jsonify(_group_detail_payload(group, launch.user["name"])), 200
 
 
 @telegram_bp.route("/api/groups/from-chat/", methods=["POST"])
@@ -76,8 +87,7 @@ def create_group_from_chat():
     if error_response:
         return error_response
 
-    data = request.get_json(silent=True) or {}
-    chat = data.get("chat") or launch.init_data.chat
+    chat = launch.init_data.chat
     if not _is_group_chat(chat):
         return jsonify({"error": "Telegram group chat context is required"}), 400
 
@@ -98,6 +108,8 @@ def join_telegram_group(group_id):
         return jsonify({"error": "Group not found"}), 404
     if group.get("source") != "telegram":
         return jsonify({"error": "Only Telegram-backed groups support self-join"}), 400
+    if not _launch_matches_group_chat(launch, group):
+        return jsonify({"error": "Verified Telegram group context is required"}), 403
 
     group = redis_service.add_user_to_group(group_id, launch.user["name"])
     return jsonify({"group": _group_payload(group)}), 200
@@ -113,54 +125,24 @@ def create_telegram_expense():
     if not data:
         return jsonify({"error": "Invalid request: invalid JSON"}), 400
 
-    for field in ["group_id", "name", "amount"]:
-        if field not in data:
-            return jsonify({"error": f"Invalid request: missing {field}"}), 400
-
-    group = redis_service.get_group(data["group_id"])
-    if not group:
-        return jsonify({"error": "Group not found"}), 404
-
-    group_users = group.get("users") or []
-    payer = launch.user["name"]
-    if payer not in group_users:
-        return jsonify({"error": "You are not a member of this group"}), 403
-
     try:
-        amount = float(data["amount"])
-    except (TypeError, ValueError):
-        return jsonify({"error": "Amount must be a number"}), 400
+        result = create_expense_for_user(launch.user["name"], data)
+    except ServiceError as exc:
+        return _service_error_response(exc)
 
-    if amount <= 0:
-        return jsonify({"error": "Amount must be greater than zero"}), 400
-
-    sharers = data.get("sharers") or group_users
-    if not isinstance(sharers, list) or not sharers:
-        return jsonify({"error": "Sharers must be a non-empty list"}), 400
-    for name in sharers:
-        if name not in group_users:
-            return jsonify({"error": "One or more sharers are not in this group"}), 404
-
-    expense_name = str(data["name"]).strip()
-    if not expense_name:
-        return jsonify({"error": "Expense name is required"}), 400
-
-    expense = Expense(
-        name=expense_name,
-        group=group["name"],
-        amount=amount,
-        payer=payer,
-        sharers=sharers,
-    )
-    saved_expense = redis_service.save_expense(expense.to_dict())
-    settlements = _save_updated_group_settlements(group, expense)
+    group = result["group"]
+    saved_expense = result["saved_expense"]
+    settlements = result["settlements"]
     _notify_telegram_group_expense(group, saved_expense)
 
     return jsonify(
         {
             "saved_expense": saved_expense,
-            "group_settlement": _named_settlements(settlements, group_users),
-            "detail": _group_detail_payload(group),
+            "group_settlement": named_settlements(
+                settlements,
+                group.get("users") or [],
+            ),
+            "detail": _group_detail_payload(group, launch.user["name"]),
         }
     ), 201
 
@@ -175,55 +157,21 @@ def update_telegram_expense(expense_id):
     if not data:
         return jsonify({"error": "Invalid request: invalid JSON"}), 400
 
-    expense = redis_service.get_expense(expense_id)
-    if not expense:
-        return jsonify({"error": "Expense not found"}), 404
+    try:
+        result = update_expense_for_user(expense_id, launch.user["name"], data)
+    except ServiceError as exc:
+        return _service_error_response(exc)
 
-    group, error_response = _expense_access_group(
-        launch.user,
-        expense,
-        require_payer=True,
-    )
-    if error_response:
-        return error_response
-
-    if "name" in data:
-        expense_name = str(data["name"]).strip()
-        if not expense_name:
-            return jsonify({"error": "Expense name is required"}), 400
-        expense["name"] = expense_name
-
-    if "amount" in data:
-        try:
-            amount = float(data["amount"])
-        except (TypeError, ValueError):
-            return jsonify({"error": "Amount must be a number"}), 400
-        if amount <= 0:
-            return jsonify({"error": "Amount must be greater than zero"}), 400
-        expense["amount"] = amount
-
-    if "sharers" in data:
-        group_users = group.get("users") or []
-        sharers = data.get("sharers")
-        if not isinstance(sharers, list) or not sharers:
-            return jsonify({"error": "Sharers must be a non-empty list"}), 400
-        for name in sharers:
-            if name not in group_users:
-                return jsonify({"error": "One or more sharers are not in this group"}), 404
-        expense["sharers"] = sharers
-
-    expense["updated_at"] = _now_iso()
-    saved_expense = redis_service.save_expense(expense)
-    settlements = _save_recomputed_group_settlements(group)
+    group = result["group"]
 
     return jsonify(
         {
-            "saved_expense": saved_expense,
-            "group_settlement": _named_settlements(
-                settlements,
+            "saved_expense": result["saved_expense"],
+            "group_settlement": named_settlements(
+                result["settlements"],
                 group.get("users") or [],
             ),
-            "detail": _group_detail_payload(group),
+            "detail": _group_detail_payload(group, launch.user["name"]),
         }
     ), 200
 
@@ -234,29 +182,21 @@ def delete_telegram_expense(expense_id):
     if error_response:
         return error_response
 
-    expense = redis_service.get_expense(expense_id)
-    if not expense:
-        return jsonify({"error": "Expense not found"}), 404
+    try:
+        result = delete_expense_for_user(expense_id, launch.user["name"])
+    except ServiceError as exc:
+        return _service_error_response(exc)
 
-    group, error_response = _expense_access_group(
-        launch.user,
-        expense,
-        require_payer=True,
-    )
-    if error_response:
-        return error_response
-
-    redis_service.delete_expense_record(expense_id)
-    settlements = _save_recomputed_group_settlements(group)
+    group = result["group"]
 
     return jsonify(
         {
             "message": f"Expense {expense_id} deleted successfully",
-            "group_settlement": _named_settlements(
-                settlements,
+            "group_settlement": named_settlements(
+                result["settlements"],
                 group.get("users") or [],
             ),
-            "detail": _group_detail_payload(group),
+            "detail": _group_detail_payload(group, launch.user["name"]),
         }
     ), 200
 
@@ -267,56 +207,22 @@ def mark_telegram_settlement_paid(group_id):
     if error_response:
         return error_response
 
-    group = redis_service.get_group(group_id)
-    if not group:
-        return jsonify({"error": "Group not found"}), 404
-
-    group_users = group.get("users") or []
-    if launch.user["name"] not in group_users:
-        return jsonify({"error": "You are not a member of this group"}), 403
-
     data = request.get_json(silent=True) or {}
-    for field in ["debtor", "creditor", "amount"]:
-        if field not in data:
-            return jsonify({"error": f"Invalid request: missing {field}"}), 400
-
-    debtor = data["debtor"]
-    creditor = data["creditor"]
-    if debtor not in group_users or creditor not in group_users:
-        return jsonify({"error": "Settlement users must be group members"}), 400
-
-    if launch.user["name"] not in {debtor, creditor}:
-        return jsonify({"error": "Only settlement participants can mark it paid"}), 403
-
     try:
-        amount = float(data["amount"])
-    except (TypeError, ValueError):
-        return jsonify({"error": "Amount must be a number"}), 400
-    if amount <= 0:
-        return jsonify({"error": "Amount must be greater than zero"}), 400
+        result = mark_settlement_paid_for_user(group_id, launch.user["name"], data)
+    except ServiceError as exc:
+        return _service_error_response(exc)
 
-    open_amount = _open_settlement_amount(group, debtor, creditor)
-    if open_amount is None:
-        return jsonify({"error": "Settlement is not open"}), 400
-    if amount - open_amount > 0.005:
-        return jsonify({"error": "Payment amount exceeds the open settlement"}), 400
-
-    payment = redis_service.save_settlement_payment(
-        group_id,
-        {
-            "debtor": debtor,
-            "creditor": creditor,
-            "amount": amount,
-            "recorded_by": launch.user["name"],
-        },
-    )
-    settlements = _save_recomputed_group_settlements(group)
+    group = result["group"]
 
     return jsonify(
         {
-            "payment": payment,
-            "group_settlement": _named_settlements(settlements, group_users),
-            "detail": _group_detail_payload(group),
+            "payment": result["payment"],
+            "group_settlement": named_settlements(
+                result["settlements"],
+                group.get("users") or [],
+            ),
+            "detail": _group_detail_payload(group, launch.user["name"]),
         }
     ), 201
 
@@ -327,7 +233,7 @@ def get_my_settlements():
     if error_response:
         return error_response
 
-    return jsonify(_user_settlements_payload(launch.user)), 200
+    return jsonify(user_settlements_payload(launch.user)), 200
 
 
 @telegram_bp.route("/webhook/", methods=["POST"])
@@ -385,10 +291,14 @@ def _auth_error_response(exc: TelegramAuthError):
     return jsonify({"error": str(exc)}), status
 
 
+def _service_error_response(exc: ServiceError):
+    return jsonify({"error": exc.message}), exc.status_code
+
+
 def _valid_webhook_secret() -> bool:
     expected = os.getenv("TELEGRAM_WEBHOOK_SECRET", "")
     if not expected:
-        return True
+        return False
     return request.headers.get("X-Telegram-Bot-Api-Secret-Token") == expected
 
 
@@ -419,15 +329,22 @@ def _group_payload(group: dict[str, Any] | None) -> dict[str, Any] | None:
     }
 
 
-def _group_detail_payload(group: dict[str, Any]) -> dict[str, Any]:
+def _group_detail_payload(
+    group: dict[str, Any],
+    current_user_name: str | None = None,
+) -> dict[str, Any]:
     expenses = redis_service.get_group_expenses(group["id"])
-    settlements = _calculate_group_settlements(group)
+    settlements = calculate_group_settlements(group)
+    named_group_settlements = named_settlements(settlements, group.get("users") or [])
     payments = redis_service.get_group_settlement_payments(group["id"])
 
     return {
         "group": _group_payload(group),
-        "expenses": expenses,
-        "settlements": _named_settlements(settlements, group.get("users") or []),
+        "expenses": expenses_with_permissions(expenses, current_user_name),
+        "settlements": settlements_with_permissions(
+            named_group_settlements,
+            current_user_name,
+        ),
         "payment_history": payments,
     }
 
@@ -442,174 +359,6 @@ def _public_user(user: dict[str, Any]) -> dict[str, Any]:
         "telegram_last_name": user.get("telegram_last_name"),
         "telegram_photo_url": user.get("telegram_photo_url"),
     }
-
-
-def _save_updated_group_settlements(
-    group: dict[str, Any],
-    _expense: Expense,
-) -> list[list]:
-    return _save_recomputed_group_settlements(group)
-
-
-def _save_recomputed_group_settlements(group: dict[str, Any]) -> list[list]:
-    tx_json = _calculate_group_settlements(group)
-    redis_service.save_group_settlements(tx_json, f"settlement-group:{group['id']}")
-    return tx_json
-
-
-def _calculate_group_settlements(group: dict[str, Any]) -> list[list]:
-    group_users = group.get("users") or []
-    group_expenses = redis_service.get_group_expenses(group["id"])
-    if not group_expenses or not group_users:
-        return []
-
-    base_settlements = Settlement(group_expenses, group_users)
-    balances = [0.0 for _ in group_users]
-
-    for debtor_idx, creditor_idx, amount in base_settlements:
-        balances[int(debtor_idx)] -= float(amount)
-        balances[int(creditor_idx)] += float(amount)
-
-    user_indexes = {name: idx for idx, name in enumerate(group_users)}
-    for payment in redis_service.get_group_settlement_payments(group["id"]):
-        debtor_idx = user_indexes.get(payment.get("debtor"))
-        creditor_idx = user_indexes.get(payment.get("creditor"))
-        if debtor_idx is None or creditor_idx is None:
-            continue
-
-        amount = float(payment.get("amount") or 0)
-        balances[debtor_idx] += amount
-        balances[creditor_idx] -= amount
-
-    return _settlements_from_balances(balances)
-
-
-def _settlements_from_balances(balances: list[float]) -> list[list]:
-    debtors = [
-        (idx, -balance)
-        for idx, balance in enumerate(balances)
-        if balance < -0.005
-    ]
-    creditors = [
-        (idx, balance)
-        for idx, balance in enumerate(balances)
-        if balance > 0.005
-    ]
-
-    settlements = []
-    debtor_idx = creditor_idx = 0
-
-    while debtor_idx < len(debtors) and creditor_idx < len(creditors):
-        debtor_user_idx, debtor_amount = debtors[debtor_idx]
-        creditor_user_idx, creditor_amount = creditors[creditor_idx]
-
-        amount = min(debtor_amount, creditor_amount)
-        settlements.append([debtor_user_idx, creditor_user_idx, amount])
-
-        debtor_amount -= amount
-        creditor_amount -= amount
-
-        if debtor_amount <= 0.005:
-            debtor_idx += 1
-        else:
-            debtors[debtor_idx] = (debtor_user_idx, debtor_amount)
-
-        if creditor_amount <= 0.005:
-            creditor_idx += 1
-        else:
-            creditors[creditor_idx] = (creditor_user_idx, creditor_amount)
-
-    return settlements
-
-
-def _expense_access_group(
-    user: dict[str, Any],
-    expense: dict[str, Any],
-    require_payer: bool = False,
-):
-    group = redis_service.get_group_by_name(expense.get("group", ""))
-    if not group:
-        return None, (jsonify({"error": "Group not found"}), 404)
-
-    group_users = group.get("users") or []
-    if user["name"] not in group_users:
-        return None, (jsonify({"error": "You are not a member of this group"}), 403)
-
-    if require_payer and expense.get("payer") != user["name"]:
-        return None, (jsonify({"error": "Only the payer can change this expense"}), 403)
-
-    return group, None
-
-
-def _open_settlement_amount(
-    group: dict[str, Any], debtor: str, creditor: str
-) -> float | None:
-    users = group.get("users") or []
-    for open_debtor, open_creditor, amount in _named_settlements(
-        _calculate_group_settlements(group),
-        users,
-    ):
-        if open_debtor == debtor and open_creditor == creditor:
-            return float(amount)
-    return None
-
-
-def _named_settlements(settlements: list, users: list[str]) -> list[list]:
-    named = []
-    for debtor_idx, creditor_idx, amount in settlements:
-        debtor_idx = int(debtor_idx)
-        creditor_idx = int(creditor_idx)
-        if debtor_idx >= len(users) or creditor_idx >= len(users):
-            continue
-        named.append([users[debtor_idx], users[creditor_idx], float(amount)])
-    return named
-
-
-def _user_settlements_payload(user: dict[str, Any]) -> dict[str, Any]:
-    user_name = user["name"]
-    grouped = []
-    aggregate: dict[str, float] = {}
-
-    for group in redis_service.get_groups_for_user(user_name):
-        detail = _group_detail_payload(group)
-        user_settlements = []
-        for debtor, creditor, amount in detail["settlements"]:
-            amount = float(amount)
-            if debtor == user_name:
-                user_settlements.append([debtor, creditor, amount])
-                aggregate[creditor] = aggregate.get(creditor, 0) - amount
-            elif creditor == user_name:
-                user_settlements.append([debtor, creditor, amount])
-                aggregate[debtor] = aggregate.get(debtor, 0) + amount
-
-        if user_settlements:
-            grouped.append(
-                {
-                    "group_id": group["id"],
-                    "group_name": group["name"],
-                    "settlements": user_settlements,
-                }
-            )
-
-    return {
-        "aggregate": _aggregate_settlements_payload(aggregate),
-        "groups": grouped,
-    }
-
-
-def _aggregate_settlements_payload(aggregate: dict[str, float]) -> list[dict[str, Any]]:
-    rows = []
-    for name, balance in sorted(aggregate.items()):
-        if abs(balance) < 1e-9:
-            continue
-        rows.append(
-            {
-                "name": name,
-                "amount": abs(balance),
-                "direction": "owes_you" if balance > 0 else "you_owe",
-            }
-        )
-    return rows
 
 
 def _handle_bot_update(update: dict[str, Any]) -> None:
@@ -663,7 +412,7 @@ def _handle_bot_update(update: dict[str, Any]) -> None:
         )
         return
 
-    if command in {"/start", "/chipin"}:
+    if command == "/chipin" or (command == "/start" and not _is_group_chat(chat)):
         if _is_group_chat(chat):
             group_name = html.escape(group["name"] if group else chat.get("title", "this group"))
             text = (
@@ -758,7 +507,7 @@ def _send_private_only_command(
 
 
 def _format_balance_message(user: dict[str, Any]) -> str:
-    settlements = _user_settlements_payload(user)["aggregate"]
+    settlements = user_settlements_payload(user)["aggregate"]
     if not settlements:
         return "You have no open ChipIn settlements."
 
@@ -789,7 +538,7 @@ def _format_groups_message(user: dict[str, Any]) -> str:
 
 
 def _format_settlements_message(user: dict[str, Any]) -> str:
-    settlements_payload = _user_settlements_payload(user)
+    settlements_payload = user_settlements_payload(user)
     if not settlements_payload["groups"]:
         return "You have no open ChipIn settlements."
 
@@ -821,10 +570,6 @@ def _format_money(amount: Any) -> str:
     return f"${float(amount or 0):.2f}"
 
 
-def _now_iso() -> str:
-    return datetime.now().isoformat()
-
-
 def _join_start_payload_group(payload: str, user: dict[str, Any] | None) -> dict[str, Any] | None:
     if not user or not payload.startswith("group_"):
         return None
@@ -833,8 +578,20 @@ def _join_start_payload_group(payload: str, user: dict[str, Any] | None) -> dict
     group = redis_service.get_group(group_id)
     if not group or group.get("source") != "telegram":
         return None
+    if user["name"] not in (group.get("users") or []):
+        return None
 
     return redis_service.add_user_to_group(group_id, user["name"])
+
+
+def _launch_matches_group_chat(
+    launch: TelegramLaunch,
+    group: dict[str, Any],
+) -> bool:
+    chat = launch.init_data.chat
+    if not _is_group_chat(chat):
+        return False
+    return str(chat.get("id")) == str(group.get("telegram_chat_id"))
 
 
 def _private_chat_reply_markup(group_id: str | None = None) -> dict[str, Any] | None:

--- a/app/services/expense_service.py
+++ b/app/services/expense_service.py
@@ -1,0 +1,160 @@
+from datetime import datetime
+from typing import Any
+
+from models.expense import Expense
+from services.redis_service import redis_service
+from services.service_errors import ServiceError
+from services.settlement_service import parse_positive_amount, save_recomputed_group_settlements
+
+
+def create_expense_for_user(
+    user_name: str,
+    data: dict[str, Any],
+) -> dict[str, Any]:
+    for field in ["group_id", "name", "amount"]:
+        if field not in data:
+            raise ServiceError(f"Invalid request: missing {field}", 400)
+
+    group = redis_service.get_group(data["group_id"])
+    if not group:
+        raise ServiceError("Group not found", 404)
+
+    group_users = group.get("users") or []
+    if user_name not in group_users:
+        raise ServiceError("You are not a member of this group", 403)
+
+    amount = parse_positive_amount(data["amount"])
+    sharers = validate_sharers(data.get("sharers") or group_users, group_users)
+    expense_name = validate_expense_name(data["name"])
+
+    expense = Expense(
+        name=expense_name,
+        group=group["name"],
+        amount=amount,
+        payer=user_name,
+        sharers=sharers,
+    )
+    expense_dict = expense.to_dict()
+    expense_dict["group_id"] = group["id"]
+    saved_expense = redis_service.save_expense(expense_dict)
+    settlements = save_recomputed_group_settlements(group)
+
+    return {
+        "group": group,
+        "saved_expense": saved_expense,
+        "settlements": settlements,
+    }
+
+
+def update_expense_for_user(
+    expense_id: str,
+    user_name: str,
+    data: dict[str, Any],
+) -> dict[str, Any]:
+    expense = redis_service.get_expense(expense_id)
+    if not expense:
+        raise ServiceError("Expense not found", 404)
+
+    group = require_expense_access_group(user_name, expense, require_payer=True)
+
+    if "name" in data:
+        expense["name"] = validate_expense_name(data["name"])
+
+    if "amount" in data:
+        expense["amount"] = parse_positive_amount(data["amount"])
+
+    if "sharers" in data:
+        expense["sharers"] = validate_sharers(
+            data.get("sharers"),
+            group.get("users") or [],
+        )
+
+    expense["updated_at"] = now_iso()
+    saved_expense = redis_service.save_expense(expense)
+    settlements = save_recomputed_group_settlements(group)
+
+    return {
+        "group": group,
+        "saved_expense": saved_expense,
+        "settlements": settlements,
+    }
+
+
+def delete_expense_for_user(
+    expense_id: str,
+    user_name: str,
+) -> dict[str, Any]:
+    expense = redis_service.get_expense(expense_id)
+    if not expense:
+        raise ServiceError("Expense not found", 404)
+
+    group = require_expense_access_group(user_name, expense, require_payer=True)
+    redis_service.delete_expense_record(expense_id)
+    settlements = save_recomputed_group_settlements(group)
+
+    return {"group": group, "settlements": settlements}
+
+
+def expenses_with_permissions(
+    expenses: list[dict[str, Any]],
+    user_name: str | None,
+) -> list[dict[str, Any]]:
+    return [expense_with_permissions(expense, user_name) for expense in expenses]
+
+
+def expense_with_permissions(
+    expense: dict[str, Any],
+    user_name: str | None,
+) -> dict[str, Any]:
+    can_change = bool(user_name and expense.get("payer") == user_name)
+    return {
+        **expense,
+        "can_edit": can_change,
+        "can_delete": can_change,
+    }
+
+
+def require_expense_access_group(
+    user_name: str,
+    expense: dict[str, Any],
+    require_payer: bool = False,
+) -> dict[str, Any]:
+    group = expense_group(expense)
+    if not group:
+        raise ServiceError("Group not found", 404)
+
+    group_users = group.get("users") or []
+    if user_name not in group_users:
+        raise ServiceError("You are not a member of this group", 403)
+
+    if require_payer and expense.get("payer") != user_name:
+        raise ServiceError("Only the payer can change this expense", 403)
+
+    return group
+
+
+def expense_group(expense: dict[str, Any]) -> dict[str, Any] | None:
+    group_id = expense.get("group_id")
+    if group_id:
+        return redis_service.get_group(group_id)
+    return redis_service.get_group_by_name(expense.get("group", ""))
+
+
+def validate_expense_name(raw_name: Any) -> str:
+    expense_name = str(raw_name).strip()
+    if not expense_name:
+        raise ServiceError("Expense name is required", 400)
+    return expense_name
+
+
+def validate_sharers(sharers: Any, group_users: list[str]) -> list[str]:
+    if not isinstance(sharers, list) or not sharers:
+        raise ServiceError("Sharers must be a non-empty list", 400)
+    for name in sharers:
+        if name not in group_users:
+            raise ServiceError("One or more sharers are not in this group", 404)
+    return sharers
+
+
+def now_iso() -> str:
+    return datetime.now().isoformat()

--- a/app/services/redis_service.py
+++ b/app/services/redis_service.py
@@ -399,6 +399,11 @@ class RedisService:
         tx_json = [list(t) for t in tx]
         self.client.json().set(settlement_key, Path.root_path(), tx_json)
         return result == 1
+
+    def delete_expense_record(self, expense_id: str) -> bool:
+        redis_key = f"expense:{expense_id}"
+        result = self.client.delete(redis_key)
+        return result == 1
     
     def get_group_expenses(self, group_id: str):
         group_dict  = self.client.json().get(f"group:{group_id}")
@@ -451,6 +456,25 @@ class RedisService:
     def get_group_settlements(self, group_id: str) -> list[list]:
         settlement_key = f"settlement-group:{group_id}"
         return self.client.json().get(settlement_key)
+
+    def save_settlement_payment(
+        self, group_id: str, payment_dict: dict[str, Any]
+    ) -> dict[str, Any]:
+        payment_key = f"settlement-payment-group:{group_id}"
+        payments = self.client.json().get(payment_key) or []
+
+        if "id" not in payment_dict:
+            payment_dict["id"] = str(uuid.uuid4())
+        if "created_at" not in payment_dict:
+            payment_dict["created_at"] = datetime.now().isoformat()
+
+        payments.append(payment_dict)
+        self.client.json().set(payment_key, Path.root_path(), payments)
+        return payment_dict
+
+    def get_group_settlement_payments(self, group_id: str) -> list[dict[str, Any]]:
+        payment_key = f"settlement-payment-group:{group_id}"
+        return self.client.json().get(payment_key) or []
     
 
 

--- a/app/services/redis_service.py
+++ b/app/services/redis_service.py
@@ -89,6 +89,7 @@ class RedisService:
             "id": expense.get("id"),
             "name": expense.get("name"),
             "group": expense.get("group"),
+            "group_id": expense.get("group_id"),
             "amount": expense.get("amount"),
             "payer": expense.get("payer"),
             "sharers": expense.get("sharers"),
@@ -260,11 +261,17 @@ class RedisService:
         if not group_name:
             return False
         
-        q = Query(f"@group:{{{group_name}}}").paging(0, 10_000)
-        res = self.client.ft("idx:expenses").search(q)
+        for key in self.client.keys("expense:*"):
+            expense = self.client.json().get(key)
+            if not expense:
+                continue
 
-        for doc in res.docs:
-            self.client.delete(doc.id)  
+            is_group_expense = expense.get("group_id") == group_id
+            is_legacy_group_expense = (
+                not expense.get("group_id") and expense.get("group") == group_name
+            )
+            if is_group_expense or is_legacy_group_expense:
+                self.client.delete(key)
 
         self.client.delete(f"settlement-group:{group_id}")
 
@@ -382,12 +389,15 @@ class RedisService:
         if not expense_dict:
             return False
         
-        group_name = expense_dict["group"]
-        group_dict = self.get_group_by_name(group_name)
+        group_id = expense_dict.get("group_id")
+        group_dict = self.get_group(group_id) if group_id else None
+        if not group_dict:
+            group_name = expense_dict["group"]
+            group_dict = self.get_group_by_name(group_name)
         if not group_dict:
             return False
         
-        group_id =  group_dict["id"]
+        group_id = group_dict["id"]
         group_users = group_dict["users"]
 
         result = self.client.delete(redis_key)
@@ -407,15 +417,20 @@ class RedisService:
     
     def get_group_expenses(self, group_id: str):
         group_dict  = self.client.json().get(f"group:{group_id}")
+        if not group_dict:
+            return []
         
-        group_name = self._escape_tag_value(group_dict["name"])
-        q = Query(f"@group:{{{group_name}}}").paging(0, 10_000)
-        res = self.client.ft("idx:expenses").search(q)
-
         group_expenses: list[dict[str, Any]] = []
-        for doc in res.docs:
-            exp = self.client.json().get(doc.id)
+        for key in self.client.keys("expense:*"):
+            exp = self.client.json().get(key)
             if not exp:
+                continue
+
+            is_group_expense = exp.get("group_id") == group_id
+            is_legacy_group_expense = (
+                not exp.get("group_id") and exp.get("group") == group_dict["name"]
+            )
+            if not is_group_expense and not is_legacy_group_expense:
                 continue
 
             group_expenses.append(self._expense_summary(exp))

--- a/app/services/redis_service.py
+++ b/app/services/redis_service.py
@@ -1,5 +1,7 @@
 import os
 import redis
+import uuid
+from datetime import datetime
 from redis.commands.json.path import Path
 from redis.commands.search.field import TextField, NumericField, TagField
 from redis.commands.search.indexDefinition import IndexDefinition, IndexType
@@ -28,6 +30,7 @@ class RedisService:
                 TextField("$.name", as_name="name"),
                 TagField("$.email", as_name="email"),
                 TagField("$.id", as_name="id"),
+                TagField("$.telegram_id", as_name="telegram_id"),
                 TextField("$.created_at", as_name="created_at"),
             )
             users_def = IndexDefinition(prefix=["user:"], index_type=IndexType.JSON)
@@ -37,6 +40,8 @@ class RedisService:
                 TextField("$.name", as_name="name"),
                 TagField("$.users[*]", as_name="users"),
                 TagField("$.id", as_name="id"),
+                TagField("$.source", as_name="source"),
+                TagField("$.telegram_chat_id", as_name="telegram_chat_id"),
                 TextField("$.created_at", as_name="created_at"),
             )
             groups_def = IndexDefinition(prefix=["group:"], index_type=IndexType.JSON)
@@ -130,6 +135,64 @@ class RedisService:
 
         return names
 
+    def get_user_by_telegram_id(self, telegram_id: int | str) -> dict[str, Any] | None:
+        target_id = str(telegram_id)
+        for user in self.get_all_users():
+            if str(user.get("telegram_id")) == target_id:
+                return user
+        return None
+
+    def upsert_telegram_user(self, telegram_user: dict[str, Any]) -> dict[str, Any]:
+        telegram_id = str(telegram_user["id"])
+        existing = self.get_user_by_telegram_id(telegram_id)
+
+        if existing:
+            existing.update(self._telegram_user_fields(telegram_user))
+            existing["updated_at"] = datetime.now().isoformat()
+            return self.save_user(existing)
+
+        name = self._unique_telegram_user_name(telegram_user)
+        user_dict = {
+            "name": name,
+            "email": f"telegram-{telegram_id}@telegram.local",
+            "id": str(uuid.uuid4()),
+            "created_at": datetime.now().isoformat(),
+            **self._telegram_user_fields(telegram_user),
+        }
+        return self.save_user(user_dict)
+
+    def _telegram_user_fields(self, telegram_user: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "source": "telegram",
+            "telegram_id": str(telegram_user["id"]),
+            "telegram_username": telegram_user.get("username"),
+            "telegram_first_name": telegram_user.get("first_name"),
+            "telegram_last_name": telegram_user.get("last_name"),
+            "telegram_photo_url": telegram_user.get("photo_url"),
+            "telegram_language_code": telegram_user.get("language_code"),
+        }
+
+    def _unique_telegram_user_name(self, telegram_user: dict[str, Any]) -> str:
+        first_name = (telegram_user.get("first_name") or "").strip()
+        last_name = (telegram_user.get("last_name") or "").strip()
+        username = (telegram_user.get("username") or "").strip()
+        telegram_id = str(telegram_user["id"])
+
+        base_name = " ".join(part for part in [first_name, last_name] if part).strip()
+        if not base_name:
+            base_name = f"@{username}" if username else f"Telegram User {telegram_id}"
+
+        existing_names = set(self.get_all_user_names())
+        if base_name not in existing_names:
+            return base_name
+
+        candidate = f"{base_name} ({telegram_id})"
+        counter = 2
+        while candidate in existing_names:
+            candidate = f"{base_name} ({telegram_id}-{counter})"
+            counter += 1
+        return candidate
+
     # Group operations
     def save_group(
         self, group_dict: dict[str, str | list[str]]
@@ -187,6 +250,74 @@ class RedisService:
         doc = res.docs[0]
         key = doc.id
         return self.client.json().get(key)
+
+    def get_group_by_telegram_chat_id(
+        self, telegram_chat_id: int | str
+    ) -> dict[str, Any] | None:
+        target_id = str(telegram_chat_id)
+        for group in self.get_all_groups():
+            if str(group.get("telegram_chat_id")) == target_id:
+                return group
+        return None
+
+    def ensure_telegram_group(self, chat: dict[str, Any]) -> dict[str, Any]:
+        chat_id = str(chat["id"])
+        existing = self.get_group_by_telegram_chat_id(chat_id)
+        if existing:
+            existing["telegram_chat_title"] = chat.get("title") or existing.get("telegram_chat_title")
+            existing["telegram_chat_type"] = chat.get("type") or existing.get("telegram_chat_type")
+            existing["updated_at"] = datetime.now().isoformat()
+            return self.save_group(existing)
+
+        name = self._unique_telegram_group_name(chat)
+        group_dict = {
+            "name": name,
+            "users": [],
+            "id": str(uuid.uuid4()),
+            "created_at": datetime.now().isoformat(),
+            "source": "telegram",
+            "telegram_chat_id": chat_id,
+            "telegram_chat_title": chat.get("title"),
+            "telegram_chat_type": chat.get("type"),
+        }
+        return self.save_group(group_dict)
+
+    def add_user_to_group(self, group_id: str, user_name: str) -> dict[str, Any] | None:
+        group = self.get_group(group_id)
+        if not group:
+            return None
+
+        users = group.get("users") or []
+        if user_name not in users:
+            users.append(user_name)
+            group["users"] = users
+            group["updated_at"] = datetime.now().isoformat()
+            self.save_group(group)
+
+        return group
+
+    def get_groups_for_user(self, user_name: str) -> list[dict[str, Any]]:
+        return [
+            group
+            for group in self.get_all_groups()
+            if user_name in (group.get("users") or [])
+        ]
+
+    def _unique_telegram_group_name(self, chat: dict[str, Any]) -> str:
+        title = (chat.get("title") or chat.get("username") or "").strip()
+        chat_id = str(chat["id"])
+        base_name = title or f"Telegram Group {chat_id}"
+
+        existing_names = {group.get("name") for group in self.get_all_groups()}
+        if base_name not in existing_names:
+            return base_name
+
+        candidate = f"{base_name} ({chat_id})"
+        counter = 2
+        while candidate in existing_names:
+            candidate = f"{base_name} ({chat_id}-{counter})"
+            counter += 1
+        return candidate
     
     # Expense operations
     def save_expense(

--- a/app/services/redis_service.py
+++ b/app/services/redis_service.py
@@ -142,28 +142,56 @@ class RedisService:
                 return user
         return None
 
+    def get_user_by_name(self, name: str) -> dict[str, Any] | None:
+        target_name = name.strip()
+        for user in self.get_all_users():
+            if user.get("name") == target_name:
+                return user
+        return None
+
     def upsert_telegram_user(self, telegram_user: dict[str, Any]) -> dict[str, Any]:
         telegram_id = str(telegram_user["id"])
         existing = self.get_user_by_telegram_id(telegram_id)
 
         if existing:
-            existing.update(self._telegram_user_fields(telegram_user))
+            existing.update(self._telegram_identity_fields(telegram_user))
             existing["updated_at"] = datetime.now().isoformat()
             return self.save_user(existing)
 
-        name = self._unique_telegram_user_name(telegram_user)
+        display_name = self._telegram_display_name(telegram_user)
+        matching_user = self.get_user_by_name(display_name)
+        if matching_user and not matching_user.get("telegram_id"):
+            return self.link_telegram_user(matching_user["id"], telegram_user)
+
         user_dict = {
-            "name": name,
+            "name": self._unique_telegram_user_name(display_name, telegram_id),
             "email": f"telegram-{telegram_id}@telegram.local",
             "id": str(uuid.uuid4()),
             "created_at": datetime.now().isoformat(),
-            **self._telegram_user_fields(telegram_user),
+            "source": "telegram",
+            **self._telegram_identity_fields(telegram_user),
         }
         return self.save_user(user_dict)
 
-    def _telegram_user_fields(self, telegram_user: dict[str, Any]) -> dict[str, Any]:
+    def link_telegram_user(
+        self, user_id: str, telegram_user: dict[str, Any]
+    ) -> dict[str, Any] | None:
+        user = self.get_user(user_id)
+        if not user:
+            return None
+
+        telegram_id = str(telegram_user["id"])
+        existing = self.get_user_by_telegram_id(telegram_id)
+        if existing and existing.get("id") != user_id:
+            return existing
+
+        user.update(self._telegram_identity_fields(telegram_user))
+        user["telegram_linked_at"] = datetime.now().isoformat()
+        user["updated_at"] = datetime.now().isoformat()
+        return self.save_user(user)
+
+    def _telegram_identity_fields(self, telegram_user: dict[str, Any]) -> dict[str, Any]:
         return {
-            "source": "telegram",
             "telegram_id": str(telegram_user["id"]),
             "telegram_username": telegram_user.get("username"),
             "telegram_first_name": telegram_user.get("first_name"),
@@ -172,16 +200,19 @@ class RedisService:
             "telegram_language_code": telegram_user.get("language_code"),
         }
 
-    def _unique_telegram_user_name(self, telegram_user: dict[str, Any]) -> str:
+    def _telegram_display_name(self, telegram_user: dict[str, Any]) -> str:
         first_name = (telegram_user.get("first_name") or "").strip()
         last_name = (telegram_user.get("last_name") or "").strip()
         username = (telegram_user.get("username") or "").strip()
         telegram_id = str(telegram_user["id"])
 
-        base_name = " ".join(part for part in [first_name, last_name] if part).strip()
-        if not base_name:
-            base_name = f"@{username}" if username else f"Telegram User {telegram_id}"
+        display_name = " ".join(part for part in [first_name, last_name] if part).strip()
+        if display_name:
+            return display_name
 
+        return f"@{username}" if username else f"Telegram User {telegram_id}"
+
+    def _unique_telegram_user_name(self, base_name: str, telegram_id: str) -> str:
         existing_names = set(self.get_all_user_names())
         if base_name not in existing_names:
             return base_name

--- a/app/services/service_errors.py
+++ b/app/services/service_errors.py
@@ -1,0 +1,5 @@
+class ServiceError(Exception):
+    def __init__(self, message: str, status_code: int = 400):
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code

--- a/app/services/settlement_service.py
+++ b/app/services/settlement_service.py
@@ -1,0 +1,233 @@
+from typing import Any
+
+from models.settlement import Settlement
+from services.redis_service import redis_service
+from services.service_errors import ServiceError
+
+
+def save_recomputed_group_settlements(group: dict[str, Any]) -> list[list]:
+    tx_json = calculate_group_settlements(group, use_saved_fallback=False)
+    redis_service.save_group_settlements(tx_json, f"settlement-group:{group['id']}")
+    return tx_json
+
+
+def calculate_group_settlements(
+    group: dict[str, Any],
+    use_saved_fallback: bool = True,
+) -> list[list]:
+    group_users = group.get("users") or []
+    group_expenses = redis_service.get_group_expenses(group["id"])
+    if not group_expenses or not group_users:
+        if use_saved_fallback:
+            return redis_service.get_group_settlements(group["id"]) or []
+        return []
+
+    base_settlements = Settlement(group_expenses, group_users)
+    balances = [0.0 for _ in group_users]
+
+    for debtor_idx, creditor_idx, amount in base_settlements:
+        balances[int(debtor_idx)] -= float(amount)
+        balances[int(creditor_idx)] += float(amount)
+
+    user_indexes = {name: idx for idx, name in enumerate(group_users)}
+    for payment in redis_service.get_group_settlement_payments(group["id"]):
+        debtor_idx = user_indexes.get(payment.get("debtor"))
+        creditor_idx = user_indexes.get(payment.get("creditor"))
+        if debtor_idx is None or creditor_idx is None:
+            continue
+
+        amount = float(payment.get("amount") or 0)
+        balances[debtor_idx] += amount
+        balances[creditor_idx] -= amount
+
+    return settlements_from_balances(balances)
+
+
+def settlements_from_balances(balances: list[float]) -> list[list]:
+    debtors = [
+        (idx, -balance)
+        for idx, balance in enumerate(balances)
+        if balance < -0.005
+    ]
+    creditors = [
+        (idx, balance)
+        for idx, balance in enumerate(balances)
+        if balance > 0.005
+    ]
+
+    settlements = []
+    debtor_idx = creditor_idx = 0
+
+    while debtor_idx < len(debtors) and creditor_idx < len(creditors):
+        debtor_user_idx, debtor_amount = debtors[debtor_idx]
+        creditor_user_idx, creditor_amount = creditors[creditor_idx]
+
+        amount = min(debtor_amount, creditor_amount)
+        settlements.append([debtor_user_idx, creditor_user_idx, amount])
+
+        debtor_amount -= amount
+        creditor_amount -= amount
+
+        if debtor_amount <= 0.005:
+            debtor_idx += 1
+        else:
+            debtors[debtor_idx] = (debtor_user_idx, debtor_amount)
+
+        if creditor_amount <= 0.005:
+            creditor_idx += 1
+        else:
+            creditors[creditor_idx] = (creditor_user_idx, creditor_amount)
+
+    return settlements
+
+
+def mark_settlement_paid_for_user(
+    group_id: str,
+    user_name: str,
+    data: dict[str, Any],
+) -> dict[str, Any]:
+    group = redis_service.get_group(group_id)
+    if not group:
+        raise ServiceError("Group not found", 404)
+
+    group_users = group.get("users") or []
+    if user_name not in group_users:
+        raise ServiceError("You are not a member of this group", 403)
+
+    for field in ["debtor", "creditor", "amount"]:
+        if field not in data:
+            raise ServiceError(f"Invalid request: missing {field}", 400)
+
+    debtor = data["debtor"]
+    creditor = data["creditor"]
+    if debtor not in group_users or creditor not in group_users:
+        raise ServiceError("Settlement users must be group members", 400)
+
+    if user_name not in {debtor, creditor}:
+        raise ServiceError("Only settlement participants can mark it paid", 403)
+
+    amount = parse_positive_amount(data["amount"])
+    open_amount = open_settlement_amount(group, debtor, creditor)
+    if open_amount is None:
+        raise ServiceError("Settlement is not open", 400)
+    if amount - open_amount > 0.005:
+        raise ServiceError("Payment amount exceeds the open settlement", 400)
+
+    payment = redis_service.save_settlement_payment(
+        group_id,
+        {
+            "debtor": debtor,
+            "creditor": creditor,
+            "amount": amount,
+            "recorded_by": user_name,
+        },
+    )
+    settlements = save_recomputed_group_settlements(group)
+    return {"group": group, "payment": payment, "settlements": settlements}
+
+
+def open_settlement_amount(
+    group: dict[str, Any],
+    debtor: str,
+    creditor: str,
+) -> float | None:
+    users = group.get("users") or []
+    for open_debtor, open_creditor, amount in named_settlements(
+        calculate_group_settlements(group),
+        users,
+    ):
+        if open_debtor == debtor and open_creditor == creditor:
+            return float(amount)
+    return None
+
+
+def named_settlements(settlements: list, users: list[str]) -> list[list]:
+    named = []
+    for debtor_idx, creditor_idx, amount in settlements:
+        debtor_idx = int(debtor_idx)
+        creditor_idx = int(creditor_idx)
+        if debtor_idx >= len(users) or creditor_idx >= len(users):
+            continue
+        named.append([users[debtor_idx], users[creditor_idx], float(amount)])
+    return named
+
+
+def settlements_with_permissions(
+    settlements: list[list],
+    user_name: str | None,
+) -> list[dict[str, Any]]:
+    enriched = []
+    for debtor, creditor, amount in settlements:
+        enriched.append(
+            {
+                "debtor": debtor,
+                "creditor": creditor,
+                "amount": float(amount),
+                "can_mark_paid": user_name in {debtor, creditor},
+            }
+        )
+    return enriched
+
+
+def user_settlements_payload(user: dict[str, Any]) -> dict[str, Any]:
+    user_name = user["name"]
+    grouped = []
+    aggregate: dict[str, float] = {}
+
+    for group in redis_service.get_groups_for_user(user_name):
+        group_settlements = named_settlements(
+            calculate_group_settlements(group),
+            group.get("users") or [],
+        )
+        user_settlements = []
+        for debtor, creditor, amount in group_settlements:
+            amount = float(amount)
+            if debtor == user_name:
+                user_settlements.append([debtor, creditor, amount])
+                aggregate[creditor] = aggregate.get(creditor, 0) - amount
+            elif creditor == user_name:
+                user_settlements.append([debtor, creditor, amount])
+                aggregate[debtor] = aggregate.get(debtor, 0) + amount
+
+        if user_settlements:
+            grouped.append(
+                {
+                    "group_id": group["id"],
+                    "group_name": group["name"],
+                    "settlements": user_settlements,
+                }
+            )
+
+    return {
+        "aggregate": aggregate_settlements_payload(aggregate),
+        "groups": grouped,
+    }
+
+
+def aggregate_settlements_payload(
+    aggregate: dict[str, float],
+) -> list[dict[str, Any]]:
+    rows = []
+    for name, balance in sorted(aggregate.items()):
+        if abs(balance) < 1e-9:
+            continue
+        rows.append(
+            {
+                "name": name,
+                "amount": abs(balance),
+                "direction": "owes_you" if balance > 0 else "you_owe",
+            }
+        )
+    return rows
+
+
+def parse_positive_amount(raw_amount: Any) -> float:
+    try:
+        amount = float(raw_amount)
+    except (TypeError, ValueError):
+        raise ServiceError("Amount must be a number", 400)
+
+    if amount <= 0:
+        raise ServiceError("Amount must be greater than zero", 400)
+
+    return amount

--- a/app/services/telegram_auth.py
+++ b/app/services/telegram_auth.py
@@ -1,0 +1,116 @@
+import hashlib
+import hmac
+import json
+import time
+from dataclasses import dataclass
+from urllib.parse import parse_qsl
+
+
+class TelegramAuthError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class TelegramInitData:
+    raw: dict[str, str]
+    user: dict
+    chat: dict | None
+    auth_date: int | None
+
+
+def _data_check_string(fields: dict[str, str], exclude_signature: bool = False) -> str:
+    excluded = {"hash"}
+    if exclude_signature:
+        excluded.add("signature")
+
+    pairs = [
+        f"{key}={value}"
+        for key, value in sorted(fields.items())
+        if key not in excluded
+    ]
+    return "\n".join(pairs)
+
+
+def _calculate_hash(data_check_string: str, bot_token: str) -> str:
+    secret_key = hmac.new(
+        b"WebAppData",
+        bot_token.encode("utf-8"),
+        hashlib.sha256,
+    ).digest()
+    return hmac.new(
+        secret_key,
+        data_check_string.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def validate_init_data(
+    init_data: str,
+    bot_token: str,
+    max_age_seconds: int | None = 24 * 60 * 60,
+) -> TelegramInitData:
+    if not bot_token:
+        raise TelegramAuthError("Telegram bot token is not configured")
+
+    if not init_data:
+        raise TelegramAuthError("Missing Telegram init data")
+
+    fields = dict(parse_qsl(init_data, keep_blank_values=True))
+    received_hash = fields.get("hash")
+    if not received_hash:
+        raise TelegramAuthError("Missing Telegram hash")
+
+    data_check_string = _data_check_string(fields)
+    expected_hash = _calculate_hash(data_check_string, bot_token)
+
+    if not hmac.compare_digest(expected_hash, received_hash):
+        # Newer init data can include a third-party signature field. Some clients
+        # still validate the bot-token hash without it, so support that shape too.
+        data_check_string = _data_check_string(fields, exclude_signature=True)
+        expected_hash = _calculate_hash(data_check_string, bot_token)
+        if not hmac.compare_digest(expected_hash, received_hash):
+            raise TelegramAuthError("Invalid Telegram hash")
+
+    auth_date = _parse_auth_date(fields.get("auth_date"))
+    if max_age_seconds is not None and auth_date is not None:
+        if int(time.time()) - auth_date > max_age_seconds:
+            raise TelegramAuthError("Telegram init data is too old")
+
+    user = _parse_json_field(fields, "user")
+    if not user or "id" not in user:
+        raise TelegramAuthError("Missing Telegram user")
+
+    chat = _parse_json_field(fields, "chat")
+
+    return TelegramInitData(
+        raw=fields,
+        user=user,
+        chat=chat,
+        auth_date=auth_date,
+    )
+
+
+def _parse_auth_date(value: str | None) -> int | None:
+    if value is None:
+        return None
+
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise TelegramAuthError("Invalid Telegram auth date") from exc
+
+
+def _parse_json_field(fields: dict[str, str], key: str) -> dict | None:
+    raw = fields.get(key)
+    if not raw:
+        return None
+
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise TelegramAuthError(f"Invalid Telegram {key}") from exc
+
+    if not isinstance(parsed, dict):
+        raise TelegramAuthError(f"Invalid Telegram {key}")
+
+    return parsed

--- a/app/services/telegram_bot.py
+++ b/app/services/telegram_bot.py
@@ -1,0 +1,54 @@
+import json
+import os
+from urllib import request as urlrequest
+from urllib.error import HTTPError, URLError
+
+
+class TelegramBotClient:
+    def __init__(self, bot_token: str | None = None):
+        self.bot_token = bot_token if bot_token is not None else os.getenv("TELEGRAM_BOT_TOKEN", "")
+
+    def send_message(
+        self,
+        chat_id: int | str,
+        text: str,
+        reply_markup: dict | None = None,
+    ) -> dict | None:
+        if not self.bot_token:
+            return None
+
+        payload = {
+            "chat_id": chat_id,
+            "text": text,
+            "parse_mode": "HTML",
+        }
+        if reply_markup is not None:
+            payload["reply_markup"] = reply_markup
+
+        return self._post("sendMessage", payload)
+
+    def _post(self, method: str, payload: dict) -> dict | None:
+        body = json.dumps(payload).encode("utf-8")
+        req = urlrequest.Request(
+            f"https://api.telegram.org/bot{self.bot_token}/{method}",
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+
+        try:
+            with urlrequest.urlopen(req, timeout=5) as response:
+                return json.loads(response.read().decode("utf-8"))
+        except HTTPError as exc:
+            try:
+                body = exc.read().decode("utf-8")
+            except OSError:
+                body = str(exc)
+            print(f"Warning: Telegram Bot API request failed: {body}")
+            return None
+        except (OSError, URLError, json.JSONDecodeError) as exc:
+            print(f"Warning: Telegram Bot API request failed: {exc}")
+            return None
+
+
+telegram_bot_client = TelegramBotClient()

--- a/app/static/admin/app.js
+++ b/app/static/admin/app.js
@@ -334,11 +334,24 @@ function renderUsersManageTable() {
         <tr data-user-row="${escapeHtml(user.id)}">
           <td><strong>${escapeHtml(user.name)}</strong></td>
           <td class="muted">${escapeHtml(user.email)}</td>
+          <td>${telegramLinkStatusMarkup(user)}</td>
           <td><small class="muted">${escapeHtml(user.id)}</small></td>
         </tr>
       `,
     )
     .join("");
+}
+
+function telegramLinkStatusMarkup(user) {
+  if (!user.telegram_id) {
+    return `<span class="status-badge" data-kind="muted">Not linked</span>`;
+  }
+
+  const label = user.telegram_username
+    ? `@${user.telegram_username}`
+    : `ID ${user.telegram_id}`;
+
+  return `<span class="status-badge" data-kind="linked">${escapeHtml(label)}</span>`;
 }
 
 function renderGroups() {

--- a/app/static/admin/index.html
+++ b/app/static/admin/index.html
@@ -187,6 +187,7 @@
                     <tr>
                       <th>Name</th>
                       <th>Email</th>
+                      <th>Telegram</th>
                       <th>ID</th>
                     </tr>
                   </thead>

--- a/app/static/admin/styles.css
+++ b/app/static/admin/styles.css
@@ -480,6 +480,29 @@ tr:last-child td {
   color: var(--muted);
 }
 
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  max-width: 170px;
+  min-height: 26px;
+  overflow: hidden;
+  padding: 4px 8px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--panel-soft);
+  color: var(--muted);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.status-badge[data-kind="linked"] {
+  border-color: rgba(36, 122, 90, 0.3);
+  background: rgba(79, 178, 134, 0.15);
+  color: var(--green-deep);
+}
+
 .empty-state {
   display: grid;
   min-height: 116px;

--- a/app/static/telegram/app.js
+++ b/app/static/telegram/app.js
@@ -150,10 +150,6 @@ function renderHeader() {
   els.userPill.textContent = state.user ? state.user.name : "";
 }
 
-function currentUserName() {
-  return state.user ? state.user.name : "";
-}
-
 function renderMetrics() {
   const net = (state.settlements.aggregate || []).reduce((sum, row) => {
     const amount = Number(row.amount) || 0;
@@ -317,31 +313,30 @@ function renderSettlements(settlements) {
   }
 
   return settlements
-    .map(
-      ([debtor, creditor, amount]) => {
-        const canMarkPaid =
-          debtor === currentUserName() || creditor === currentUserName();
-        return `
-          <div class="row">
-            <div class="row-main">
-              <span class="row-title">${escapeHtml(debtor)} to ${escapeHtml(creditor)}</span>
-              <span class="row-value">${money.format(Number(amount) || 0)}</span>
-            </div>
-            ${
-              canMarkPaid
-                ? `<div class="row-actions">
-                    <button class="secondary-button" type="button"
-                      data-mark-paid
-                      data-debtor="${escapeHtml(debtor)}"
-                      data-creditor="${escapeHtml(creditor)}"
-                      data-amount="${escapeHtml(amount)}">Mark Paid</button>
-                  </div>`
-                : ""
-            }
+    .map((row) => {
+      const settlement = settlementPayload(row);
+      return `
+        <div class="row">
+          <div class="row-main">
+            <span class="row-title">
+              ${escapeHtml(settlement.debtor)} to ${escapeHtml(settlement.creditor)}
+            </span>
+            <span class="row-value">${money.format(Number(settlement.amount) || 0)}</span>
           </div>
-        `;
-      },
-    )
+          ${
+            settlement.can_mark_paid
+              ? `<div class="row-actions">
+                  <button class="secondary-button" type="button"
+                    data-mark-paid
+                    data-debtor="${escapeHtml(settlement.debtor)}"
+                    data-creditor="${escapeHtml(settlement.creditor)}"
+                    data-amount="${escapeHtml(settlement.amount)}">Mark Paid</button>
+                </div>`
+              : ""
+          }
+        </div>
+      `;
+    })
     .join("");
 }
 
@@ -353,7 +348,6 @@ function renderExpenses(expenses) {
   return expenses
     .map(
       (expense) => {
-        const canChange = expense.payer === currentUserName();
         return `
           <div class="row">
             <div class="row-main">
@@ -365,12 +359,20 @@ function renderExpenses(expenses) {
               <span>${(expense.sharers || []).length} sharers</span>
             </div>
             ${
-              canChange
+              expense.can_edit || expense.can_delete
                 ? `<div class="row-actions">
-                    <button class="secondary-button" type="button"
-                      data-edit-expense="${escapeHtml(expense.id)}">Edit</button>
-                    <button class="danger-button" type="button"
-                      data-delete-expense="${escapeHtml(expense.id)}">Delete</button>
+                    ${
+                      expense.can_edit
+                        ? `<button class="secondary-button" type="button"
+                            data-edit-expense="${escapeHtml(expense.id)}">Edit</button>`
+                        : ""
+                    }
+                    ${
+                      expense.can_delete
+                        ? `<button class="danger-button" type="button"
+                            data-delete-expense="${escapeHtml(expense.id)}">Delete</button>`
+                        : ""
+                    }
                   </div>`
                 : ""
             }
@@ -379,6 +381,19 @@ function renderExpenses(expenses) {
       },
     )
     .join("");
+}
+
+function settlementPayload(row) {
+  if (!Array.isArray(row)) {
+    return row || {};
+  }
+
+  return {
+    debtor: row[0],
+    creditor: row[1],
+    amount: row[2],
+    can_mark_paid: false,
+  };
 }
 
 function renderPaymentHistory(payments) {

--- a/app/static/telegram/app.js
+++ b/app/static/telegram/app.js
@@ -1,0 +1,407 @@
+"use strict";
+
+const tg = window.Telegram && window.Telegram.WebApp ? window.Telegram.WebApp : null;
+
+const state = {
+  initData: tg ? tg.initData : "",
+  requestedGroupId: new URLSearchParams(window.location.search).get("group_id") || "",
+  user: null,
+  groups: [],
+  settlements: { aggregate: [], groups: [] },
+  selectedGroupId: "",
+  detail: null,
+};
+
+const els = {
+  status: document.querySelector("#status"),
+  dashboard: document.querySelector("#dashboard"),
+  userPill: document.querySelector("#user-pill"),
+  groupsCount: document.querySelector("#groups-count"),
+  netBalance: document.querySelector("#net-balance"),
+  balancesList: document.querySelector("#balances-list"),
+  groupsList: document.querySelector("#groups-list"),
+  groupDetail: document.querySelector("#group-detail"),
+  toast: document.querySelector("#toast"),
+};
+
+const money = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+});
+
+function escapeHtml(value) {
+  return String(value == null ? "" : value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+function setStatus(stateName, text) {
+  els.status.dataset.state = stateName;
+  els.status.textContent = text;
+  els.status.hidden = false;
+}
+
+let toastTimer;
+function showToast(message, kind = "info") {
+  window.clearTimeout(toastTimer);
+  els.toast.textContent = message;
+  els.toast.dataset.kind = kind;
+  els.toast.classList.add("is-visible");
+  toastTimer = window.setTimeout(() => {
+    els.toast.classList.remove("is-visible");
+  }, 2800);
+}
+
+function haptic(kind) {
+  if (!tg || !tg.HapticFeedback) {
+    return;
+  }
+
+  if (kind === "success" || kind === "error") {
+    tg.HapticFeedback.notificationOccurred(kind);
+  } else {
+    tg.HapticFeedback.selectionChanged();
+  }
+}
+
+async function api(path, options = {}) {
+  const response = await fetch(path, {
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      "X-Telegram-Init-Data": state.initData,
+      ...(options.headers || {}),
+    },
+  });
+
+  const contentType = response.headers.get("content-type") || "";
+  const payload = contentType.includes("application/json")
+    ? await response.json()
+    : await response.text();
+
+  if (!response.ok) {
+    const message =
+      typeof payload === "object" && payload !== null
+        ? payload.error || payload.warning || JSON.stringify(payload)
+        : payload || "Request failed";
+    throw new Error(message);
+  }
+
+  return payload;
+}
+
+async function authenticate() {
+  if (!state.initData) {
+    throw new Error("Open ChipIn from Telegram to continue.");
+  }
+
+  return api("/telegram/auth/", {
+    method: "POST",
+    body: JSON.stringify({ init_data: state.initData }),
+  });
+}
+
+async function refreshGroups() {
+  const [groupsPayload, settlementsPayload] = await Promise.all([
+    api("/telegram/api/groups/"),
+    api("/telegram/api/settlements/"),
+  ]);
+
+  state.groups = groupsPayload.groups || [];
+  state.settlements = settlementsPayload || { aggregate: [], groups: [] };
+
+  if (
+    state.selectedGroupId &&
+    !state.groups.some((group) => group.id === state.selectedGroupId)
+  ) {
+    state.selectedGroupId = "";
+    state.detail = null;
+  }
+}
+
+async function loadGroup(groupId) {
+  if (!groupId) {
+    state.detail = null;
+    render();
+    return;
+  }
+
+  const detail = await api(`/telegram/api/groups/${encodeURIComponent(groupId)}/`);
+  state.selectedGroupId = groupId;
+  state.detail = detail;
+  render();
+}
+
+function render() {
+  els.dashboard.hidden = false;
+  els.status.hidden = true;
+  renderHeader();
+  renderMetrics();
+  renderBalances();
+  renderGroups();
+  renderGroupDetail();
+}
+
+function renderHeader() {
+  els.userPill.textContent = state.user ? state.user.name : "";
+}
+
+function renderMetrics() {
+  const net = (state.settlements.aggregate || []).reduce((sum, row) => {
+    const amount = Number(row.amount) || 0;
+    return sum + (row.direction === "owes_you" ? amount : -amount);
+  }, 0);
+
+  els.groupsCount.textContent = String(state.groups.length);
+  els.netBalance.textContent = money.format(net);
+}
+
+function renderBalances() {
+  const balances = state.settlements.aggregate || [];
+  if (!balances.length) {
+    els.balancesList.innerHTML = `<div class="empty">No open balances</div>`;
+    return;
+  }
+
+  els.balancesList.innerHTML = balances
+    .map((row) => {
+      const isPositive = row.direction === "owes_you";
+      const label = isPositive ? "owes you" : "you owe";
+      return `
+        <div class="row">
+          <div class="row-main">
+            <span class="row-title">${escapeHtml(row.name)}</span>
+            <span class="row-value ${isPositive ? "good" : "bad"}">
+              ${money.format(Number(row.amount) || 0)}
+            </span>
+          </div>
+          <div class="row-meta">${escapeHtml(label)}</div>
+        </div>
+      `;
+    })
+    .join("");
+}
+
+function renderGroups() {
+  if (!state.groups.length) {
+    els.groupsList.innerHTML = `<div class="empty">No groups yet</div>`;
+    return;
+  }
+
+  els.groupsList.innerHTML = state.groups
+    .map(
+      (group) => `
+        <button class="group-item" data-group-id="${escapeHtml(group.id)}"
+          aria-current="${group.id === state.selectedGroupId ? "true" : "false"}">
+          <span class="row-main">
+            <span class="row-title">${escapeHtml(group.name)}</span>
+            <span class="row-value">${Number(group.expenses_count) || 0}</span>
+          </span>
+          <span class="row-meta">
+            <span>ID ${escapeHtml(group.id)}</span>
+            <span>${(group.users || []).length} users</span>
+            <span>${escapeHtml(group.source || "manual")}</span>
+          </span>
+        </button>
+      `,
+    )
+    .join("");
+}
+
+function renderGroupDetail() {
+  const detail = state.detail;
+  if (!detail || !detail.group) {
+    els.groupDetail.hidden = true;
+    els.groupDetail.innerHTML = "";
+    return;
+  }
+
+  const group = detail.group;
+  const users = group.users || [];
+
+  els.groupDetail.hidden = false;
+  els.groupDetail.innerHTML = `
+    <div class="section-title">
+      <h2>${escapeHtml(group.name)}</h2>
+    </div>
+    <div class="detail-body">
+      <div class="subsection">
+        <h3>Members</h3>
+        <div class="chips">
+          ${users.map((name) => `<span class="chip">${escapeHtml(name)}</span>`).join("")}
+        </div>
+      </div>
+
+      <form id="expense-form" class="expense-form">
+        <div class="field">
+          <label for="expense-name">Expense</label>
+          <input id="expense-name" name="name" type="text" required autocomplete="off">
+        </div>
+        <div class="field">
+          <label for="expense-amount">Amount</label>
+          <input id="expense-amount" name="amount" type="number" min="0.01" step="0.01" required>
+        </div>
+        <fieldset class="check-list">
+          <legend>Sharers</legend>
+          <div class="check-options">
+            ${users
+              .map(
+                (name) => `
+                  <label class="check-item">
+                    <input type="checkbox" name="sharers" value="${escapeHtml(name)}" checked>
+                    <span>${escapeHtml(name)}</span>
+                  </label>
+                `,
+              )
+              .join("")}
+          </div>
+        </fieldset>
+        <button class="primary-button" type="submit">Add Expense</button>
+      </form>
+
+      <div class="subsection">
+        <h3>Settlements</h3>
+        <div class="list">${renderSettlements(detail.settlements || [])}</div>
+      </div>
+
+      <div class="subsection">
+        <h3>Expenses</h3>
+        <div class="list">${renderExpenses(detail.expenses || [])}</div>
+      </div>
+    </div>
+  `;
+}
+
+function renderSettlements(settlements) {
+  if (!settlements.length) {
+    return `<div class="empty">No settlements</div>`;
+  }
+
+  return settlements
+    .map(
+      ([debtor, creditor, amount]) => `
+        <div class="row">
+          <div class="row-main">
+            <span class="row-title">${escapeHtml(debtor)} to ${escapeHtml(creditor)}</span>
+            <span class="row-value">${money.format(Number(amount) || 0)}</span>
+          </div>
+        </div>
+      `,
+    )
+    .join("");
+}
+
+function renderExpenses(expenses) {
+  if (!expenses.length) {
+    return `<div class="empty">No expenses</div>`;
+  }
+
+  return expenses
+    .map(
+      (expense) => `
+        <div class="row">
+          <div class="row-main">
+            <span class="row-title">${escapeHtml(expense.name)}</span>
+            <span class="row-value">${money.format(Number(expense.amount) || 0)}</span>
+          </div>
+          <div class="row-meta">
+            <span>${escapeHtml(expense.payer)}</span>
+            <span>${(expense.sharers || []).length} sharers</span>
+          </div>
+        </div>
+      `,
+    )
+    .join("");
+}
+
+els.groupsList.addEventListener("click", async (event) => {
+  const button = event.target.closest("[data-group-id]");
+  if (!button) {
+    return;
+  }
+
+  try {
+    haptic("select");
+    await loadGroup(button.dataset.groupId);
+  } catch (error) {
+    haptic("error");
+    showToast(error.message, "error");
+  }
+});
+
+els.groupDetail.addEventListener("submit", async (event) => {
+  const form = event.target.closest("#expense-form");
+  if (!form) {
+    return;
+  }
+
+  event.preventDefault();
+
+  const formData = new FormData(form);
+  const sharers = formData.getAll("sharers");
+
+  try {
+    await api("/telegram/api/expenses/", {
+      method: "POST",
+      body: JSON.stringify({
+        group_id: state.selectedGroupId,
+        name: formData.get("name"),
+        amount: formData.get("amount"),
+        sharers,
+      }),
+    });
+
+    form.reset();
+    await refreshGroups();
+    await loadGroup(state.selectedGroupId);
+    haptic("success");
+    showToast("Expense added");
+  } catch (error) {
+    haptic("error");
+    showToast(error.message, "error");
+  }
+});
+
+async function start() {
+  if (tg) {
+    tg.ready();
+    tg.expand();
+  }
+
+  try {
+    setStatus("loading", "Loading");
+    const payload = await authenticate();
+    state.user = payload.user;
+    state.groups = payload.groups || [];
+    state.settlements = payload.settlements || { aggregate: [], groups: [] };
+    state.selectedGroupId = selectInitialGroup(payload);
+
+    render();
+    if (state.selectedGroupId) {
+      await loadGroup(state.selectedGroupId);
+    }
+  } catch (error) {
+    els.dashboard.hidden = true;
+    setStatus("error", error.message);
+  }
+}
+
+start();
+
+function selectInitialGroup(payload) {
+  if (
+    state.requestedGroupId &&
+    state.groups.some((group) => group.id === state.requestedGroupId)
+  ) {
+    return state.requestedGroupId;
+  }
+
+  if (payload.launch_group) {
+    return payload.launch_group.id;
+  }
+
+  return state.groups[0] ? state.groups[0].id : "";
+}

--- a/app/static/telegram/app.js
+++ b/app/static/telegram/app.js
@@ -9,6 +9,7 @@ const state = {
   groups: [],
   settlements: { aggregate: [], groups: [] },
   selectedGroupId: "",
+  editingExpenseId: "",
   detail: null,
 };
 
@@ -149,6 +150,10 @@ function renderHeader() {
   els.userPill.textContent = state.user ? state.user.name : "";
 }
 
+function currentUserName() {
+  return state.user ? state.user.name : "";
+}
+
 function renderMetrics() {
   const net = (state.settlements.aggregate || []).reduce((sum, row) => {
     const amount = Number(row.amount) || 0;
@@ -221,11 +226,20 @@ function renderGroupDetail() {
 
   const group = detail.group;
   const users = group.users || [];
+  const editingExpense = (detail.expenses || []).find(
+    (expense) => expense.id === state.editingExpenseId,
+  );
+  const selectedSharers = editingExpense ? editingExpense.sharers || [] : users;
 
   els.groupDetail.hidden = false;
   els.groupDetail.innerHTML = `
     <div class="section-title">
       <h2>${escapeHtml(group.name)}</h2>
+      ${
+        group.private_chat_url
+          ? `<button class="secondary-button" type="button" data-open-bot="${escapeHtml(group.private_chat_url)}">Open Bot</button>`
+          : ""
+      }
     </div>
     <div class="detail-body">
       <div class="subsection">
@@ -238,28 +252,30 @@ function renderGroupDetail() {
       <form id="expense-form" class="expense-form">
         <div class="field">
           <label for="expense-name">Expense</label>
-          <input id="expense-name" name="name" type="text" required autocomplete="off">
+          <input id="expense-name" name="name" type="text" required autocomplete="off"
+            value="${escapeHtml(editingExpense ? editingExpense.name : "")}">
         </div>
         <div class="field">
           <label for="expense-amount">Amount</label>
-          <input id="expense-amount" name="amount" type="number" min="0.01" step="0.01" required>
+          <input id="expense-amount" name="amount" type="number" min="0.01" step="0.01" required
+            value="${escapeHtml(editingExpense ? editingExpense.amount : "")}">
         </div>
         <fieldset class="check-list">
           <legend>Sharers</legend>
           <div class="check-options">
-            ${users
-              .map(
-                (name) => `
-                  <label class="check-item">
-                    <input type="checkbox" name="sharers" value="${escapeHtml(name)}" checked>
-                    <span>${escapeHtml(name)}</span>
-                  </label>
-                `,
-              )
-              .join("")}
+            ${renderSharerInputs(users, selectedSharers)}
           </div>
         </fieldset>
-        <button class="primary-button" type="submit">Add Expense</button>
+        <div class="button-row">
+          <button class="primary-button" type="submit">
+            ${editingExpense ? "Save Expense" : "Add Expense"}
+          </button>
+          ${
+            editingExpense
+              ? `<button class="secondary-button" type="button" data-cancel-edit>Cancel</button>`
+              : ""
+          }
+        </div>
       </form>
 
       <div class="subsection">
@@ -271,8 +287,28 @@ function renderGroupDetail() {
         <h3>Expenses</h3>
         <div class="list">${renderExpenses(detail.expenses || [])}</div>
       </div>
+
+      <div class="subsection">
+        <h3>Payment History</h3>
+        <div class="list">${renderPaymentHistory(detail.payment_history || [])}</div>
+      </div>
     </div>
   `;
+}
+
+function renderSharerInputs(users, selectedSharers) {
+  const selected = new Set(selectedSharers);
+  return users
+    .map(
+      (name) => `
+        <label class="check-item">
+          <input type="checkbox" name="sharers" value="${escapeHtml(name)}"
+            ${selected.has(name) ? "checked" : ""}>
+          <span>${escapeHtml(name)}</span>
+        </label>
+      `,
+    )
+    .join("");
 }
 
 function renderSettlements(settlements) {
@@ -282,14 +318,29 @@ function renderSettlements(settlements) {
 
   return settlements
     .map(
-      ([debtor, creditor, amount]) => `
-        <div class="row">
-          <div class="row-main">
-            <span class="row-title">${escapeHtml(debtor)} to ${escapeHtml(creditor)}</span>
-            <span class="row-value">${money.format(Number(amount) || 0)}</span>
+      ([debtor, creditor, amount]) => {
+        const canMarkPaid =
+          debtor === currentUserName() || creditor === currentUserName();
+        return `
+          <div class="row">
+            <div class="row-main">
+              <span class="row-title">${escapeHtml(debtor)} to ${escapeHtml(creditor)}</span>
+              <span class="row-value">${money.format(Number(amount) || 0)}</span>
+            </div>
+            ${
+              canMarkPaid
+                ? `<div class="row-actions">
+                    <button class="secondary-button" type="button"
+                      data-mark-paid
+                      data-debtor="${escapeHtml(debtor)}"
+                      data-creditor="${escapeHtml(creditor)}"
+                      data-amount="${escapeHtml(amount)}">Mark Paid</button>
+                  </div>`
+                : ""
+            }
           </div>
-        </div>
-      `,
+        `;
+      },
     )
     .join("");
 }
@@ -301,15 +352,53 @@ function renderExpenses(expenses) {
 
   return expenses
     .map(
-      (expense) => `
+      (expense) => {
+        const canChange = expense.payer === currentUserName();
+        return `
+          <div class="row">
+            <div class="row-main">
+              <span class="row-title">${escapeHtml(expense.name)}</span>
+              <span class="row-value">${money.format(Number(expense.amount) || 0)}</span>
+            </div>
+            <div class="row-meta">
+              <span>${escapeHtml(expense.payer)}</span>
+              <span>${(expense.sharers || []).length} sharers</span>
+            </div>
+            ${
+              canChange
+                ? `<div class="row-actions">
+                    <button class="secondary-button" type="button"
+                      data-edit-expense="${escapeHtml(expense.id)}">Edit</button>
+                    <button class="danger-button" type="button"
+                      data-delete-expense="${escapeHtml(expense.id)}">Delete</button>
+                  </div>`
+                : ""
+            }
+          </div>
+        `;
+      },
+    )
+    .join("");
+}
+
+function renderPaymentHistory(payments) {
+  if (!payments.length) {
+    return `<div class="empty">No paid settlements yet</div>`;
+  }
+
+  return [...payments]
+    .reverse()
+    .map(
+      (payment) => `
         <div class="row">
           <div class="row-main">
-            <span class="row-title">${escapeHtml(expense.name)}</span>
-            <span class="row-value">${money.format(Number(expense.amount) || 0)}</span>
+            <span class="row-title">
+              ${escapeHtml(payment.debtor)} paid ${escapeHtml(payment.creditor)}
+            </span>
+            <span class="row-value">${money.format(Number(payment.amount) || 0)}</span>
           </div>
           <div class="row-meta">
-            <span>${escapeHtml(expense.payer)}</span>
-            <span>${(expense.sharers || []).length} sharers</span>
+            <span>Recorded by ${escapeHtml(payment.recorded_by || "")}</span>
           </div>
         </div>
       `,
@@ -344,8 +433,13 @@ els.groupDetail.addEventListener("submit", async (event) => {
   const sharers = formData.getAll("sharers");
 
   try {
-    await api("/telegram/api/expenses/", {
-      method: "POST",
+    const isEditing = Boolean(state.editingExpenseId);
+    const path = isEditing
+      ? `/telegram/api/expenses/${encodeURIComponent(state.editingExpenseId)}/`
+      : "/telegram/api/expenses/";
+
+    await api(path, {
+      method: isEditing ? "PUT" : "POST",
       body: JSON.stringify({
         group_id: state.selectedGroupId,
         name: formData.get("name"),
@@ -354,16 +448,105 @@ els.groupDetail.addEventListener("submit", async (event) => {
       }),
     });
 
+    state.editingExpenseId = "";
     form.reset();
     await refreshGroups();
     await loadGroup(state.selectedGroupId);
     haptic("success");
-    showToast("Expense added");
+    showToast(isEditing ? "Expense updated" : "Expense added");
   } catch (error) {
     haptic("error");
     showToast(error.message, "error");
   }
 });
+
+els.groupDetail.addEventListener("click", async (event) => {
+  const openBotButton = event.target.closest("[data-open-bot]");
+  if (openBotButton) {
+    openBot(openBotButton.dataset.openBot);
+    return;
+  }
+
+  if (event.target.closest("[data-cancel-edit]")) {
+    state.editingExpenseId = "";
+    renderGroupDetail();
+    return;
+  }
+
+  const editButton = event.target.closest("[data-edit-expense]");
+  if (editButton) {
+    state.editingExpenseId = editButton.dataset.editExpense;
+    renderGroupDetail();
+    return;
+  }
+
+  const deleteButton = event.target.closest("[data-delete-expense]");
+  if (deleteButton) {
+    await deleteExpense(deleteButton.dataset.deleteExpense);
+    return;
+  }
+
+  const paidButton = event.target.closest("[data-mark-paid]");
+  if (paidButton) {
+    await markSettlementPaid({
+      debtor: paidButton.dataset.debtor,
+      creditor: paidButton.dataset.creditor,
+      amount: paidButton.dataset.amount,
+    });
+  }
+});
+
+function openBot(url) {
+  if (!url) {
+    return;
+  }
+
+  if (tg && tg.openTelegramLink) {
+    tg.openTelegramLink(url);
+    return;
+  }
+
+  window.open(url, "_blank", "noopener");
+}
+
+async function deleteExpense(expenseId) {
+  if (!expenseId || !window.confirm("Delete this expense?")) {
+    return;
+  }
+
+  try {
+    await api(`/telegram/api/expenses/${encodeURIComponent(expenseId)}/`, {
+      method: "DELETE",
+    });
+    state.editingExpenseId = "";
+    await refreshGroups();
+    await loadGroup(state.selectedGroupId);
+    haptic("success");
+    showToast("Expense deleted");
+  } catch (error) {
+    haptic("error");
+    showToast(error.message, "error");
+  }
+}
+
+async function markSettlementPaid({ debtor, creditor, amount }) {
+  try {
+    await api(
+      `/telegram/api/groups/${encodeURIComponent(state.selectedGroupId)}/settlements/paid/`,
+      {
+        method: "POST",
+        body: JSON.stringify({ debtor, creditor, amount }),
+      },
+    );
+    await refreshGroups();
+    await loadGroup(state.selectedGroupId);
+    haptic("success");
+    showToast("Settlement marked paid");
+  } catch (error) {
+    haptic("error");
+    showToast(error.message, "error");
+  }
+}
 
 async function start() {
   if (tg) {

--- a/app/static/telegram/index.html
+++ b/app/static/telegram/index.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>ChipIn</title>
+    <link rel="stylesheet" href="/static/telegram/styles.css">
+    <script src="https://telegram.org/js/telegram-web-app.js"></script>
+  </head>
+  <body>
+    <div class="app-shell">
+      <header class="app-header">
+        <div class="brand">
+          <img src="/static/admin/chipin-mark.svg" alt="" class="brand-mark">
+          <div>
+            <p>ChipIn</p>
+            <h1>Client</h1>
+          </div>
+        </div>
+        <span id="user-pill" class="user-pill"></span>
+      </header>
+
+      <main>
+        <section id="status" class="status" data-state="loading">Loading</section>
+
+        <section id="dashboard" class="dashboard" hidden>
+          <div class="metrics">
+            <div>
+              <span id="groups-count">0</span>
+              <p>Groups</p>
+            </div>
+            <div>
+              <span id="net-balance">$0.00</span>
+              <p>Net Balance</p>
+            </div>
+          </div>
+
+          <section class="section">
+            <div class="section-title">
+              <h2>Balances</h2>
+            </div>
+            <div id="balances-list" class="list"></div>
+          </section>
+
+          <section class="section">
+            <div class="section-title">
+              <h2>Groups</h2>
+            </div>
+            <div id="groups-list" class="group-list"></div>
+          </section>
+
+          <section id="group-detail" class="section detail-section" hidden></section>
+        </section>
+      </main>
+
+      <div id="toast" class="toast" role="status"></div>
+    </div>
+
+    <script src="/static/telegram/app.js"></script>
+  </body>
+</html>

--- a/app/static/telegram/styles.css
+++ b/app/static/telegram/styles.css
@@ -330,13 +330,48 @@ button {
   white-space: nowrap;
 }
 
-.primary-button {
+.button-row,
+.row-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.button-row {
+  align-items: center;
+}
+
+.row-actions {
+  margin-top: 2px;
+}
+
+.primary-button,
+.secondary-button,
+.danger-button {
   min-height: 44px;
-  border: 0;
+  padding: 0 12px;
   border-radius: 8px;
+  font-weight: 740;
+}
+
+.primary-button {
+  border: 0;
   color: var(--accent-text);
   background: var(--accent);
-  font-weight: 740;
+}
+
+.secondary-button,
+.danger-button {
+  border: 1px solid var(--line);
+  background: var(--surface);
+}
+
+.secondary-button {
+  color: var(--text);
+}
+
+.danger-button {
+  color: var(--bad);
 }
 
 .toast {

--- a/app/static/telegram/styles.css
+++ b/app/static/telegram/styles.css
@@ -1,0 +1,376 @@
+:root {
+  --bg: var(--tg-theme-bg-color, #f6f7f9);
+  --text: var(--tg-theme-text-color, #18202b);
+  --hint: var(--tg-theme-hint-color, #69717d);
+  --surface: var(--tg-theme-section-bg-color, #ffffff);
+  --surface-2: var(--tg-theme-secondary-bg-color, #eef2f5);
+  --line: var(--tg-theme-section-separator-color, #d9e0e6);
+  --accent: var(--tg-theme-button-color, #2f80ed);
+  --accent-text: var(--tg-theme-button-text-color, #ffffff);
+  --good: #14804a;
+  --bad: #b42318;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--text);
+  background: var(--bg);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+button,
+input {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+.app-shell {
+  width: min(100%, 720px);
+  margin: 0 auto;
+  padding: calc(14px + var(--tg-safe-area-inset-top, 0px)) 14px
+    calc(24px + var(--tg-safe-area-inset-bottom, 0px));
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  gap: 10px;
+}
+
+.brand-mark {
+  width: 38px;
+  height: 38px;
+}
+
+.brand p,
+.brand h1,
+.metrics p,
+.section-title h2 {
+  margin: 0;
+}
+
+.brand p {
+  color: var(--hint);
+  font-size: 0.78rem;
+}
+
+.brand h1 {
+  font-size: 1.28rem;
+  font-weight: 750;
+}
+
+.user-pill {
+  max-width: 46%;
+  overflow: hidden;
+  padding: 6px 9px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--hint);
+  background: var(--surface);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.78rem;
+}
+
+.status,
+.section,
+.metrics {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.status {
+  padding: 14px;
+  color: var(--hint);
+}
+
+.status[data-state="error"] {
+  color: var(--bad);
+}
+
+.dashboard {
+  display: grid;
+  gap: 12px;
+}
+
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  overflow: hidden;
+}
+
+.metrics div {
+  padding: 14px;
+}
+
+.metrics div + div {
+  border-left: 1px solid var(--line);
+}
+
+.metrics span {
+  display: block;
+  overflow-wrap: anywhere;
+  font-size: 1.25rem;
+  font-weight: 760;
+}
+
+.metrics p {
+  margin-top: 2px;
+  color: var(--hint);
+  font-size: 0.78rem;
+}
+
+.section {
+  overflow: hidden;
+}
+
+.section-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--line);
+}
+
+.section-title h2 {
+  font-size: 0.94rem;
+  font-weight: 740;
+}
+
+.list,
+.group-list {
+  display: grid;
+}
+
+.empty {
+  padding: 14px;
+  color: var(--hint);
+}
+
+.group-item,
+.row {
+  display: grid;
+  gap: 4px;
+  width: 100%;
+  min-height: 64px;
+  padding: 12px 14px;
+  border: 0;
+  border-bottom: 1px solid var(--line);
+  color: var(--text);
+  background: transparent;
+  text-align: left;
+}
+
+.group-item:last-child,
+.row:last-child {
+  border-bottom: 0;
+}
+
+.group-item[aria-current="true"] {
+  background: var(--surface-2);
+}
+
+.row-main {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.row-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 710;
+}
+
+.row-value {
+  flex: 0 0 auto;
+  font-weight: 710;
+}
+
+.row-value.good {
+  color: var(--good);
+}
+
+.row-value.bad {
+  color: var(--bad);
+}
+
+.row-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  color: var(--hint);
+  font-size: 0.76rem;
+}
+
+.detail-body {
+  display: grid;
+  gap: 14px;
+  padding: 14px;
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.chip {
+  max-width: 100%;
+  overflow: hidden;
+  padding: 5px 8px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--hint);
+  background: var(--surface-2);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.76rem;
+}
+
+.subsection {
+  display: grid;
+  gap: 8px;
+}
+
+.subsection h3 {
+  margin: 0;
+  font-size: 0.86rem;
+}
+
+.expense-form {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface-2);
+}
+
+.field {
+  display: grid;
+  gap: 5px;
+}
+
+.field label,
+.check-list legend {
+  color: var(--hint);
+  font-size: 0.76rem;
+  font-weight: 650;
+}
+
+.field input {
+  width: 100%;
+  min-height: 42px;
+  padding: 9px 10px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--text);
+  background: var(--surface);
+}
+
+.check-list {
+  display: grid;
+  gap: 7px;
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.check-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.check-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 100%;
+  padding: 6px 8px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--surface);
+  font-size: 0.78rem;
+}
+
+.check-item span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.primary-button {
+  min-height: 44px;
+  border: 0;
+  border-radius: 8px;
+  color: var(--accent-text);
+  background: var(--accent);
+  font-weight: 740;
+}
+
+.toast {
+  position: fixed;
+  left: 14px;
+  right: 14px;
+  bottom: calc(14px + var(--tg-safe-area-inset-bottom, 0px));
+  z-index: 10;
+  max-width: 692px;
+  margin: 0 auto;
+  padding: 11px 12px;
+  border-radius: 8px;
+  color: #ffffff;
+  background: rgba(24, 32, 43, 0.92);
+  opacity: 0;
+  transform: translateY(12px);
+  transition:
+    opacity 160ms ease,
+    transform 160ms ease;
+  pointer-events: none;
+}
+
+.toast.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (max-width: 430px) {
+  .app-shell {
+    padding-right: 10px;
+    padding-left: 10px;
+  }
+
+  .user-pill {
+    max-width: 42%;
+  }
+}

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -243,12 +243,14 @@ class MockRedisService:
                 "id": expense.get("id"),
                 "name": expense.get("name"),
                 "group": expense.get("group"),
+                "group_id": expense.get("group_id"),
                 "amount": expense.get("amount"),
                 "payer": expense.get("payer"),
                 "sharers": expense.get("sharers"),
             }
             for expense in self.get_all_expenses()
-            if expense.get("group") == group["name"]
+            if expense.get("group_id") == group_id
+            or (not expense.get("group_id") and expense.get("group") == group["name"])
         ]
 
     def get_user_paid_expenses(self, user_id):
@@ -315,6 +317,8 @@ def mock_redis_service(monkeypatch):
     import routes.expenses as expenses_module
     import routes.settlements as settlements_module
     import routes.telegram as telegram_module
+    import services.expense_service as expense_service_module
+    import services.settlement_service as settlement_service_module
 
     mock_service = MockRedisService()
 
@@ -325,6 +329,8 @@ def mock_redis_service(monkeypatch):
     monkeypatch.setattr(expenses_module, "redis_service", mock_service)
     monkeypatch.setattr(settlements_module, "redis_service", mock_service)
     monkeypatch.setattr(telegram_module, "redis_service", mock_service)
+    monkeypatch.setattr(expense_service_module, "redis_service", mock_service)
+    monkeypatch.setattr(settlement_service_module, "redis_service", mock_service)
 
     yield mock_service
 

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -1,6 +1,8 @@
 import pytest
 import sys
 import os
+import uuid
+from datetime import datetime
 
 # Add backend to path
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
@@ -36,6 +38,52 @@ class MockRedisService:
     def get_all_user_names(self):
         return [user["name"] for user in self.get_all_users()]
 
+    def get_user_by_telegram_id(self, telegram_id):
+        target_id = str(telegram_id)
+        for user in self.get_all_users():
+            if str(user.get("telegram_id")) == target_id:
+                return user
+        return None
+
+    def upsert_telegram_user(self, telegram_user):
+        telegram_id = str(telegram_user["id"])
+        existing = self.get_user_by_telegram_id(telegram_id)
+
+        fields = {
+            "source": "telegram",
+            "telegram_id": telegram_id,
+            "telegram_username": telegram_user.get("username"),
+            "telegram_first_name": telegram_user.get("first_name"),
+            "telegram_last_name": telegram_user.get("last_name"),
+            "telegram_photo_url": telegram_user.get("photo_url"),
+            "telegram_language_code": telegram_user.get("language_code"),
+        }
+
+        if existing:
+            existing.update(fields)
+            existing["updated_at"] = datetime.now().isoformat()
+            return self.save_user(existing)
+
+        first_name = (telegram_user.get("first_name") or "").strip()
+        last_name = (telegram_user.get("last_name") or "").strip()
+        username = (telegram_user.get("username") or "").strip()
+        base_name = " ".join(part for part in [first_name, last_name] if part)
+        if not base_name:
+            base_name = f"@{username}" if username else f"Telegram User {telegram_id}"
+
+        existing_names = set(self.get_all_user_names())
+        name = base_name if base_name not in existing_names else f"{base_name} ({telegram_id})"
+
+        return self.save_user(
+            {
+                "name": name,
+                "email": f"telegram-{telegram_id}@telegram.local",
+                "id": str(uuid.uuid4()),
+                "created_at": datetime.now().isoformat(),
+                **fields,
+            }
+        )
+
     # Group Operations
     def save_group(self, group_dict):
         key = f"group:{group_dict['id']}"
@@ -55,8 +103,138 @@ class MockRedisService:
 
     def delete_group(self, group_id):
         key = f"group:{group_id}"
-        self.data.pop(key)
-        return key not in self.data.keys()
+        existed = key in self.data
+        self.data.pop(key, None)
+        return existed and key not in self.data.keys()
+
+    def get_group_by_name(self, name):
+        for group in self.get_all_groups():
+            if group["name"] == name:
+                return group
+        return None
+
+    def get_group_by_telegram_chat_id(self, telegram_chat_id):
+        target_id = str(telegram_chat_id)
+        for group in self.get_all_groups():
+            if str(group.get("telegram_chat_id")) == target_id:
+                return group
+        return None
+
+    def ensure_telegram_group(self, chat):
+        chat_id = str(chat["id"])
+        existing = self.get_group_by_telegram_chat_id(chat_id)
+        if existing:
+            existing["telegram_chat_title"] = chat.get("title") or existing.get("telegram_chat_title")
+            existing["telegram_chat_type"] = chat.get("type") or existing.get("telegram_chat_type")
+            existing["updated_at"] = datetime.now().isoformat()
+            return self.save_group(existing)
+
+        title = chat.get("title") or chat.get("username") or f"Telegram Group {chat_id}"
+        name = title
+        existing_names = {group["name"] for group in self.get_all_groups()}
+        if name in existing_names:
+            name = f"{title} ({chat_id})"
+
+        return self.save_group(
+            {
+                "name": name,
+                "users": [],
+                "id": str(uuid.uuid4()),
+                "created_at": datetime.now().isoformat(),
+                "source": "telegram",
+                "telegram_chat_id": chat_id,
+                "telegram_chat_title": chat.get("title"),
+                "telegram_chat_type": chat.get("type"),
+            }
+        )
+
+    def add_user_to_group(self, group_id, user_name):
+        group = self.get_group(group_id)
+        if not group:
+            return None
+
+        users = group.get("users") or []
+        if user_name not in users:
+            users.append(user_name)
+            group["users"] = users
+            group["updated_at"] = datetime.now().isoformat()
+            self.save_group(group)
+
+        return group
+
+    def get_groups_for_user(self, user_name):
+        return [
+            group
+            for group in self.get_all_groups()
+            if user_name in (group.get("users") or [])
+        ]
+
+    # Expense Operations
+    def save_expense(self, expense_dict):
+        key = f"expense:{expense_dict['id']}"
+        self.data[key] = expense_dict
+        return expense_dict
+
+    def get_all_expenses(self):
+        return [v for k, v in self.data.items() if k.startswith("expense:")]
+
+    def get_expense(self, expense_id):
+        key = f"expense:{expense_id}"
+        return self.data.get(key)
+
+    def get_expense_attr(self, expense_id, key):
+        expense = self.get_expense(expense_id)
+        return expense.get(key) if expense else None
+
+    def delete_expense(self, expense_id):
+        key = f"expense:{expense_id}"
+        existed = key in self.data
+        self.data.pop(key, None)
+        return existed and key not in self.data.keys()
+
+    def get_group_expenses(self, group_id):
+        group = self.get_group(group_id)
+        if not group:
+            return []
+
+        return [
+            {
+                "id": expense.get("id"),
+                "name": expense.get("name"),
+                "group": expense.get("group"),
+                "amount": expense.get("amount"),
+                "payer": expense.get("payer"),
+                "sharers": expense.get("sharers"),
+            }
+            for expense in self.get_all_expenses()
+            if expense.get("group") == group["name"]
+        ]
+
+    def get_user_paid_expenses(self, user_id):
+        user = self.get_user(user_id)
+        if not user:
+            return []
+
+        return [
+            expense
+            for expense in self.get_all_expenses()
+            if expense.get("payer") == user["name"]
+        ]
+
+    # Settlement Operations
+    def save_group_settlements(self, settlement, key):
+        self.data[key] = settlement
+        return settlement
+
+    def get_all_group_settlements(self):
+        return {
+            key: value
+            for key, value in self.data.items()
+            if key.startswith("settlement-group:")
+        }
+
+    def get_group_settlements(self, group_id):
+        return self.data.get(f"settlement-group:{group_id}")
 
 
 @pytest.fixture
@@ -78,6 +256,9 @@ def mock_redis_service(monkeypatch):
     import services.redis_service as redis_module
     import routes.users as users_module
     import routes.groups as groups_module
+    import routes.expenses as expenses_module
+    import routes.settlements as settlements_module
+    import routes.telegram as telegram_module
 
     mock_service = MockRedisService()
 
@@ -85,6 +266,9 @@ def mock_redis_service(monkeypatch):
     monkeypatch.setattr(redis_module, "redis_service", mock_service)
     monkeypatch.setattr(users_module, "redis_service", mock_service)
     monkeypatch.setattr(groups_module, "redis_service", mock_service)
+    monkeypatch.setattr(expenses_module, "redis_service", mock_service)
+    monkeypatch.setattr(settlements_module, "redis_service", mock_service)
+    monkeypatch.setattr(telegram_module, "redis_service", mock_service)
 
     yield mock_service
 

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -45,6 +45,13 @@ class MockRedisService:
                 return user
         return None
 
+    def get_user_by_name(self, name):
+        target_name = name.strip()
+        for user in self.get_all_users():
+            if user.get("name") == target_name:
+                return user
+        return None
+
     def upsert_telegram_user(self, telegram_user):
         telegram_id = str(telegram_user["id"])
         existing = self.get_user_by_telegram_id(telegram_id)
@@ -71,6 +78,10 @@ class MockRedisService:
         if not base_name:
             base_name = f"@{username}" if username else f"Telegram User {telegram_id}"
 
+        matching_user = self.get_user_by_name(base_name)
+        if matching_user and not matching_user.get("telegram_id"):
+            return self.link_telegram_user(matching_user["id"], telegram_user)
+
         existing_names = set(self.get_all_user_names())
         name = base_name if base_name not in existing_names else f"{base_name} ({telegram_id})"
 
@@ -83,6 +94,30 @@ class MockRedisService:
                 **fields,
             }
         )
+
+    def link_telegram_user(self, user_id, telegram_user):
+        user = self.get_user(user_id)
+        if not user:
+            return None
+
+        telegram_id = str(telegram_user["id"])
+        existing = self.get_user_by_telegram_id(telegram_id)
+        if existing and existing.get("id") != user_id:
+            return existing
+
+        user.update(
+            {
+                "telegram_id": telegram_id,
+                "telegram_username": telegram_user.get("username"),
+                "telegram_first_name": telegram_user.get("first_name"),
+                "telegram_last_name": telegram_user.get("last_name"),
+                "telegram_photo_url": telegram_user.get("photo_url"),
+                "telegram_language_code": telegram_user.get("language_code"),
+                "telegram_linked_at": datetime.now().isoformat(),
+                "updated_at": datetime.now().isoformat(),
+            }
+        )
+        return self.save_user(user)
 
     # Group Operations
     def save_group(self, group_dict):

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -227,6 +227,12 @@ class MockRedisService:
         self.data.pop(key, None)
         return existed and key not in self.data.keys()
 
+    def delete_expense_record(self, expense_id):
+        key = f"expense:{expense_id}"
+        existed = key in self.data
+        self.data.pop(key, None)
+        return existed and key not in self.data.keys()
+
     def get_group_expenses(self, group_id):
         group = self.get_group(group_id)
         if not group:
@@ -270,6 +276,21 @@ class MockRedisService:
 
     def get_group_settlements(self, group_id):
         return self.data.get(f"settlement-group:{group_id}")
+
+    def save_settlement_payment(self, group_id, payment_dict):
+        key = f"settlement-payment-group:{group_id}"
+        payments = self.data.get(key, [])
+        payment_dict = dict(payment_dict)
+        if "id" not in payment_dict:
+            payment_dict["id"] = str(uuid.uuid4())
+        if "created_at" not in payment_dict:
+            payment_dict["created_at"] = datetime.now().isoformat()
+        payments.append(payment_dict)
+        self.data[key] = payments
+        return payment_dict
+
+    def get_group_settlement_payments(self, group_id):
+        return self.data.get(f"settlement-payment-group:{group_id}", [])
 
 
 @pytest.fixture

--- a/app/tests/test_telegram.py
+++ b/app/tests/test_telegram.py
@@ -70,6 +70,67 @@ def test_telegram_auth_valid_init_data_upserts_user(client, monkeypatch):
     assert data["groups"] == []
 
 
+def test_telegram_auth_links_existing_user_by_display_name(
+    client, monkeypatch, mock_redis_service
+):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", BOT_TOKEN)
+    existing_user = mock_redis_service.save_user(
+        {
+            "name": "Moein",
+            "email": "moein@example.com",
+            "id": "existing-user-id",
+            "created_at": "2026-06-21T00:00:00",
+        }
+    )
+    init_data = make_init_data(
+        {"id": 1001, "first_name": "Moein", "username": "moein"}
+    )
+
+    response = client.post(
+        "/telegram/auth/",
+        data=json.dumps({"init_data": init_data}),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    linked_user = mock_redis_service.get_user(existing_user["id"])
+    assert data["user"]["id"] == "existing-user-id"
+    assert linked_user["telegram_id"] == "1001"
+    assert linked_user["telegram_username"] == "moein"
+    assert linked_user["email"] == "moein@example.com"
+    assert "telegram_linked_at" in linked_user
+
+
+def test_telegram_auth_does_not_duplicate_matching_existing_user(
+    client, monkeypatch, mock_redis_service
+):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", BOT_TOKEN)
+    mock_redis_service.save_user(
+        {
+            "name": "Moein",
+            "email": "moein@example.com",
+            "id": "existing-user-id",
+            "created_at": "2026-06-21T00:00:00",
+        }
+    )
+    init_data = make_init_data(
+        {"id": 1001, "first_name": "Moein", "username": "moein"}
+    )
+
+    response = client.post(
+        "/telegram/auth/",
+        data=json.dumps({"init_data": init_data}),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200
+    users = mock_redis_service.get_all_users()
+    assert len(users) == 1
+    assert users[0]["id"] == "existing-user-id"
+    assert users[0]["telegram_id"] == "1001"
+
+
 def test_telegram_auth_rejects_tampered_init_data(client, monkeypatch):
     monkeypatch.setenv("TELEGRAM_BOT_TOKEN", BOT_TOKEN)
     init_data = make_init_data({"id": 1001, "first_name": "Moein"})

--- a/app/tests/test_telegram.py
+++ b/app/tests/test_telegram.py
@@ -47,19 +47,33 @@ class FakeBot:
         )
 
 
-def save_manual_group(mock_redis_service, users=None):
+def save_manual_group(
+    mock_redis_service,
+    users=None,
+    group_id="p2-group-id",
+    name="P2 Trip",
+    source="manual",
+    telegram_chat_id=None,
+):
     return mock_redis_service.save_group(
         {
-            "name": "P2 Trip",
-            "users": users or ["Moein", "Bob"],
-            "id": "p2-group-id",
+            "name": name,
+            "users": ["Moein", "Bob"] if users is None else users,
+            "id": group_id,
             "created_at": "2026-06-21T00:00:00",
-            "source": "manual",
+            "source": source,
+            "telegram_chat_id": telegram_chat_id,
         }
     )
 
 
-def create_telegram_expense(client, init_data, group_id, amount=20):
+def create_telegram_expense(
+    client,
+    init_data,
+    group_id,
+    amount=20,
+    sharers=None,
+):
     response = client.post(
         "/telegram/api/expenses/",
         data=json.dumps(
@@ -67,7 +81,7 @@ def create_telegram_expense(client, init_data, group_id, amount=20):
                 "group_id": group_id,
                 "name": "Dinner",
                 "amount": amount,
-                "sharers": ["Moein", "Bob"],
+                "sharers": sharers or ["Moein", "Bob"],
             }
         ),
         content_type="application/json",
@@ -208,6 +222,82 @@ def test_telegram_auth_creates_group_from_chat_and_self_joins(client, monkeypatc
     assert data["groups"][0]["id"] == data["launch_group"]["id"]
 
 
+def test_telegram_create_group_from_chat_rejects_forged_body_chat(
+    client, monkeypatch, mock_redis_service
+):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", BOT_TOKEN)
+    init_data = make_init_data({"id": 1001, "first_name": "Moein"})
+
+    response = client.post(
+        "/telegram/api/groups/from-chat/",
+        data=json.dumps(
+            {
+                "chat": {
+                    "id": -2001,
+                    "type": "group",
+                    "title": "Forged Group",
+                }
+            }
+        ),
+        content_type="application/json",
+        headers=auth_headers(init_data),
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "Telegram group chat context is required"
+    assert mock_redis_service.get_all_groups() == []
+
+
+def test_telegram_join_group_requires_verified_group_context(
+    client, monkeypatch, mock_redis_service
+):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", BOT_TOKEN)
+    group = save_manual_group(
+        mock_redis_service,
+        users=[],
+        group_id="telegram-group-id",
+        name="Calgary Trip",
+        source="telegram",
+        telegram_chat_id="-2001",
+    )
+    private_init_data = make_init_data({"id": 1001, "first_name": "Moein"})
+
+    response = client.post(
+        f"/telegram/api/groups/{group['id']}/join/",
+        headers=auth_headers(private_init_data),
+    )
+
+    assert response.status_code == 403
+    assert response.get_json()["error"] == "Verified Telegram group context is required"
+    assert mock_redis_service.get_group(group["id"])["users"] == []
+
+
+def test_telegram_join_group_accepts_verified_group_launch(
+    client, monkeypatch, mock_redis_service
+):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", BOT_TOKEN)
+    group = save_manual_group(
+        mock_redis_service,
+        users=[],
+        group_id="telegram-group-id",
+        name="Calgary Trip",
+        source="telegram",
+        telegram_chat_id="-2001",
+    )
+    group_init_data = make_init_data(
+        {"id": 1001, "first_name": "Moein"},
+        {"id": -2001, "type": "group", "title": "Calgary Trip"},
+    )
+
+    response = client.post(
+        f"/telegram/api/groups/{group['id']}/join/",
+        headers=auth_headers(group_init_data),
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["group"]["users"] == ["Moein"]
+
+
 def test_telegram_expense_creation_uses_authenticated_user(
     client, monkeypatch, mock_redis_service
 ):
@@ -256,7 +346,9 @@ def test_telegram_expense_creation_uses_authenticated_user(
     data = response.get_json()
     assert data["saved_expense"]["payer"] == "Moein"
     assert data["saved_expense"]["group"] == "Calgary Trip"
+    assert data["saved_expense"]["group_id"] == group["id"]
     assert data["group_settlement"] == [["Bob", "Moein", 10.0]]
+    assert mock_redis_service.get_group_settlements(group["id"]) == [[1, 0, 10.0]]
     assert len(fake_bot.messages) == 1
     assert fake_bot.messages[0]["chat_id"] == "-2001"
     assert "Moein added <b>Dinner</b>" in fake_bot.messages[0]["text"]
@@ -301,6 +393,50 @@ def test_telegram_expense_update_requires_payer_and_recomputes_settlements(
     assert data["saved_expense"]["amount"] == 30.0
     assert "updated_at" in data["saved_expense"]
     assert data["group_settlement"] == [["Bob", "Moein", 15.0]]
+    assert mock_redis_service.get_group_settlements(group["id"]) == [[1, 0, 15.0]]
+
+
+def test_telegram_expense_access_uses_group_id_with_duplicate_group_names(
+    client, monkeypatch, mock_redis_service
+):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", BOT_TOKEN)
+    save_manual_group(
+        mock_redis_service,
+        users=["Moein", "Bob"],
+        group_id="same-name-a",
+        name="Same Name",
+    )
+    group = save_manual_group(
+        mock_redis_service,
+        users=["Moein", "Cara"],
+        group_id="same-name-b",
+        name="Same Name",
+    )
+    moein_init_data = make_init_data({"id": 1001, "first_name": "Moein"})
+    expense = create_telegram_expense(
+        client,
+        moein_init_data,
+        group["id"],
+        sharers=["Moein", "Cara"],
+    )
+
+    response = client.put(
+        f"/telegram/api/expenses/{expense['id']}/",
+        data=json.dumps(
+            {
+                "amount": 40,
+                "sharers": ["Moein", "Cara"],
+            }
+        ),
+        content_type="application/json",
+        headers=auth_headers(moein_init_data),
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["saved_expense"]["group_id"] == "same-name-b"
+    assert data["detail"]["group"]["id"] == "same-name-b"
+    assert data["group_settlement"] == [["Cara", "Moein", 20.0]]
 
 
 def test_telegram_expense_delete_requires_payer_and_recomputes_settlements(
@@ -329,6 +465,7 @@ def test_telegram_expense_delete_requires_payer_and_recomputes_settlements(
     data = response.get_json()
     assert mock_redis_service.get_expense(expense["id"]) is None
     assert data["group_settlement"] == []
+    assert mock_redis_service.get_group_settlements(group["id"]) == []
 
 
 def test_telegram_mark_settlement_paid_records_history_and_closes_balance(
@@ -354,6 +491,10 @@ def test_telegram_mark_settlement_paid_records_history_and_closes_balance(
     assert data["payment"]["recorded_by"] == "Bob"
     assert data["group_settlement"] == []
     assert data["detail"]["payment_history"] == [data["payment"]]
+    assert mock_redis_service.get_group_settlement_payments(group["id"]) == [
+        data["payment"]
+    ]
+    assert mock_redis_service.get_group_settlements(group["id"]) == []
 
     duplicate_response = client.post(
         f"/telegram/api/groups/{group['id']}/settlements/paid/",
@@ -578,6 +719,44 @@ def test_telegram_webhook_requires_secret(client, monkeypatch):
     assert response.status_code == 403
 
 
+def test_telegram_webhook_rejects_missing_secret_configuration(client, monkeypatch):
+    monkeypatch.delenv("TELEGRAM_WEBHOOK_SECRET", raising=False)
+
+    response = client.post(
+        "/telegram/webhook/",
+        data=json.dumps({"update_id": 1}),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 403
+
+
+def test_telegram_webhook_rejects_wrong_secret(client, monkeypatch):
+    monkeypatch.setenv("TELEGRAM_WEBHOOK_SECRET", "secret")
+
+    response = client.post(
+        "/telegram/webhook/",
+        data=json.dumps({"update_id": 1}),
+        content_type="application/json",
+        headers={"X-Telegram-Bot-Api-Secret-Token": "wrong"},
+    )
+
+    assert response.status_code == 403
+
+
+def test_telegram_webhook_accepts_correct_secret(client, monkeypatch):
+    monkeypatch.setenv("TELEGRAM_WEBHOOK_SECRET", "secret")
+
+    response = client.post(
+        "/telegram/webhook/",
+        data=json.dumps({"update_id": 1}),
+        content_type="application/json",
+        headers={"X-Telegram-Bot-Api-Secret-Token": "secret"},
+    )
+
+    assert response.status_code == 200
+
+
 def test_telegram_webhook_links_group_and_sends_button(client, monkeypatch):
     import routes.telegram as telegram_module
 
@@ -623,6 +802,33 @@ def test_telegram_webhook_links_group_and_sends_button(client, monkeypatch):
     assert parse_qs(parsed_url.query)["start"][0].startswith("group_")
 
 
+def test_telegram_group_start_command_is_ignored(client, monkeypatch):
+    import routes.telegram as telegram_module
+
+    fake_bot = FakeBot()
+    monkeypatch.setenv("TELEGRAM_WEBHOOK_SECRET", "secret")
+    monkeypatch.setattr(telegram_module, "telegram_bot_client", fake_bot)
+
+    response = client.post(
+        "/telegram/webhook/",
+        data=json.dumps(
+            {
+                "update_id": 1,
+                "message": {
+                    "chat": {"id": -2001, "type": "group", "title": "Calgary Trip"},
+                    "from": {"id": 1001, "first_name": "Moein"},
+                    "text": "/start",
+                },
+            }
+        ),
+        content_type="application/json",
+        headers={"X-Telegram-Bot-Api-Secret-Token": "secret"},
+    )
+
+    assert response.status_code == 200
+    assert fake_bot.messages == []
+
+
 def test_telegram_private_start_payload_joins_group_and_sends_web_app(
     client, monkeypatch, mock_redis_service
 ):
@@ -641,6 +847,7 @@ def test_telegram_private_start_payload_joins_group_and_sends_web_app(
     group = mock_redis_service.ensure_telegram_group(
         {"id": -2001, "type": "group", "title": "Calgary Trip"}
     )
+    mock_redis_service.add_user_to_group(group["id"], "Moein")
     monkeypatch.setenv("TELEGRAM_WEBHOOK_SECRET", "secret")
     monkeypatch.setenv("PUBLIC_BASE_URL", "https://chipin.example")
     monkeypatch.setattr(telegram_module, "telegram_bot_client", fake_bot)
@@ -670,3 +877,37 @@ def test_telegram_private_start_payload_joins_group_and_sends_web_app(
         "https://chipin.example/telegram/"
     )
     assert parse_qs(parsed_url.query)["group_id"] == [group["id"]]
+
+
+def test_telegram_private_start_payload_does_not_join_unlinked_user(
+    client, monkeypatch, mock_redis_service
+):
+    import routes.telegram as telegram_module
+
+    fake_bot = FakeBot()
+    group = mock_redis_service.ensure_telegram_group(
+        {"id": -2001, "type": "group", "title": "Calgary Trip"}
+    )
+    monkeypatch.setenv("TELEGRAM_WEBHOOK_SECRET", "secret")
+    monkeypatch.setenv("PUBLIC_BASE_URL", "https://chipin.example")
+    monkeypatch.setattr(telegram_module, "telegram_bot_client", fake_bot)
+
+    response = client.post(
+        "/telegram/webhook/",
+        data=json.dumps(
+            {
+                "update_id": 1,
+                "message": {
+                    "chat": {"id": 1001, "type": "private", "first_name": "Moein"},
+                    "from": {"id": 1001, "first_name": "Moein"},
+                    "text": f"/start group_{group['id']}",
+                },
+            }
+        ),
+        content_type="application/json",
+        headers={"X-Telegram-Bot-Api-Secret-Token": "secret"},
+    )
+
+    assert response.status_code == 200
+    assert mock_redis_service.get_group(group["id"])["users"] == []
+    assert "I could not find that ChipIn group" in fake_bot.messages[0]["text"]

--- a/app/tests/test_telegram.py
+++ b/app/tests/test_telegram.py
@@ -37,6 +37,16 @@ def auth_headers(init_data):
     return {"X-Telegram-Init-Data": init_data}
 
 
+class FakeBot:
+    def __init__(self):
+        self.messages = []
+
+    def send_message(self, chat_id, text, reply_markup=None):
+        self.messages.append(
+            {"chat_id": chat_id, "text": text, "reply_markup": reply_markup}
+        )
+
+
 def test_telegram_client_served(client):
     response = client.get("/telegram/")
 
@@ -171,7 +181,12 @@ def test_telegram_auth_creates_group_from_chat_and_self_joins(client, monkeypatc
 def test_telegram_expense_creation_uses_authenticated_user(
     client, monkeypatch, mock_redis_service
 ):
+    import routes.telegram as telegram_module
+
+    fake_bot = FakeBot()
     monkeypatch.setenv("TELEGRAM_BOT_TOKEN", BOT_TOKEN)
+    monkeypatch.setenv("TELEGRAM_BOT_USERNAME", "chipin_test_bot")
+    monkeypatch.setattr(telegram_module, "telegram_bot_client", fake_bot)
     init_data = make_init_data(
         {"id": 1001, "first_name": "Moein"},
         {"id": -2001, "type": "group", "title": "Calgary Trip"},
@@ -212,6 +227,201 @@ def test_telegram_expense_creation_uses_authenticated_user(
     assert data["saved_expense"]["payer"] == "Moein"
     assert data["saved_expense"]["group"] == "Calgary Trip"
     assert data["group_settlement"] == [["Bob", "Moein", 10.0]]
+    assert len(fake_bot.messages) == 1
+    assert fake_bot.messages[0]["chat_id"] == "-2001"
+    assert "Moein added <b>Dinner</b>" in fake_bot.messages[0]["text"]
+    button = fake_bot.messages[0]["reply_markup"]["inline_keyboard"][0][0]
+    assert button["url"].startswith("https://t.me/chipin_test_bot?start=group_")
+
+
+def test_telegram_help_command_lists_commands(client, monkeypatch):
+    import routes.telegram as telegram_module
+
+    fake_bot = FakeBot()
+    monkeypatch.setenv("TELEGRAM_WEBHOOK_SECRET", "secret")
+    monkeypatch.setenv("PUBLIC_BASE_URL", "https://chipin.example")
+    monkeypatch.setattr(telegram_module, "telegram_bot_client", fake_bot)
+
+    response = client.post(
+        "/telegram/webhook/",
+        data=json.dumps(
+            {
+                "update_id": 1,
+                "message": {
+                    "chat": {"id": 1001, "type": "private", "first_name": "Moein"},
+                    "from": {"id": 1001, "first_name": "Moein"},
+                    "text": "/help",
+                },
+            }
+        ),
+        content_type="application/json",
+        headers={"X-Telegram-Bot-Api-Secret-Token": "secret"},
+    )
+
+    assert response.status_code == 200
+    assert "/groups" in fake_bot.messages[0]["text"]
+    assert "/settlements" in fake_bot.messages[0]["text"]
+
+
+def test_telegram_groups_command_lists_private_groups(
+    client, monkeypatch, mock_redis_service
+):
+    import routes.telegram as telegram_module
+
+    fake_bot = FakeBot()
+    monkeypatch.setenv("TELEGRAM_WEBHOOK_SECRET", "secret")
+    monkeypatch.setenv("PUBLIC_BASE_URL", "https://chipin.example")
+    monkeypatch.setattr(telegram_module, "telegram_bot_client", fake_bot)
+
+    user = mock_redis_service.upsert_telegram_user(
+        {"id": 1001, "first_name": "Moein"}
+    )
+    group = mock_redis_service.ensure_telegram_group(
+        {"id": -2001, "type": "group", "title": "Calgary Trip"}
+    )
+    mock_redis_service.add_user_to_group(group["id"], user["name"])
+
+    response = client.post(
+        "/telegram/webhook/",
+        data=json.dumps(
+            {
+                "update_id": 1,
+                "message": {
+                    "chat": {"id": 1001, "type": "private", "first_name": "Moein"},
+                    "from": {"id": 1001, "first_name": "Moein"},
+                    "text": "/groups",
+                },
+            }
+        ),
+        content_type="application/json",
+        headers={"X-Telegram-Bot-Api-Secret-Token": "secret"},
+    )
+
+    assert response.status_code == 200
+    assert "Your ChipIn groups:" in fake_bot.messages[0]["text"]
+    assert "Calgary Trip" in fake_bot.messages[0]["text"]
+
+
+def test_telegram_balance_command_reports_private_balance(
+    client, monkeypatch, mock_redis_service
+):
+    import routes.telegram as telegram_module
+
+    fake_bot = FakeBot()
+    monkeypatch.setenv("TELEGRAM_WEBHOOK_SECRET", "secret")
+    monkeypatch.setenv("PUBLIC_BASE_URL", "https://chipin.example")
+    monkeypatch.setattr(telegram_module, "telegram_bot_client", fake_bot)
+
+    user = mock_redis_service.upsert_telegram_user(
+        {"id": 1001, "first_name": "Moein"}
+    )
+    group = mock_redis_service.ensure_telegram_group(
+        {"id": -2001, "type": "group", "title": "Calgary Trip"}
+    )
+    mock_redis_service.add_user_to_group(group["id"], user["name"])
+    mock_redis_service.add_user_to_group(group["id"], "Bob")
+    mock_redis_service.save_group_settlements(
+        [[1, 0, 10.0]],
+        f"settlement-group:{group['id']}",
+    )
+
+    response = client.post(
+        "/telegram/webhook/",
+        data=json.dumps(
+            {
+                "update_id": 1,
+                "message": {
+                    "chat": {"id": 1001, "type": "private", "first_name": "Moein"},
+                    "from": {"id": 1001, "first_name": "Moein"},
+                    "text": "/balance",
+                },
+            }
+        ),
+        content_type="application/json",
+        headers={"X-Telegram-Bot-Api-Secret-Token": "secret"},
+    )
+
+    assert response.status_code == 200
+    assert "Your ChipIn balance:" in fake_bot.messages[0]["text"]
+    assert "Bob owes you $10.00" in fake_bot.messages[0]["text"]
+
+
+def test_telegram_balance_command_in_group_uses_private_handoff(
+    client, monkeypatch
+):
+    import routes.telegram as telegram_module
+
+    fake_bot = FakeBot()
+    monkeypatch.setenv("TELEGRAM_WEBHOOK_SECRET", "secret")
+    monkeypatch.setenv("TELEGRAM_BOT_USERNAME", "chipin_test_bot")
+    monkeypatch.setattr(telegram_module, "telegram_bot_client", fake_bot)
+
+    response = client.post(
+        "/telegram/webhook/",
+        data=json.dumps(
+            {
+                "update_id": 1,
+                "message": {
+                    "chat": {"id": -2001, "type": "group", "title": "Calgary Trip"},
+                    "from": {"id": 1001, "first_name": "Moein"},
+                    "text": "/balance",
+                },
+            }
+        ),
+        content_type="application/json",
+        headers={"X-Telegram-Bot-Api-Secret-Token": "secret"},
+    )
+
+    assert response.status_code == 200
+    assert fake_bot.messages[0]["chat_id"] == -2001
+    assert "Open ChipIn privately" in fake_bot.messages[0]["text"]
+    button = fake_bot.messages[0]["reply_markup"]["inline_keyboard"][0][0]
+    assert button["url"].startswith("https://t.me/chipin_test_bot?start=group_")
+
+
+def test_telegram_settlements_command_lists_private_settlements(
+    client, monkeypatch, mock_redis_service
+):
+    import routes.telegram as telegram_module
+
+    fake_bot = FakeBot()
+    monkeypatch.setenv("TELEGRAM_WEBHOOK_SECRET", "secret")
+    monkeypatch.setenv("PUBLIC_BASE_URL", "https://chipin.example")
+    monkeypatch.setattr(telegram_module, "telegram_bot_client", fake_bot)
+
+    user = mock_redis_service.upsert_telegram_user(
+        {"id": 1001, "first_name": "Moein"}
+    )
+    group = mock_redis_service.ensure_telegram_group(
+        {"id": -2001, "type": "group", "title": "Calgary Trip"}
+    )
+    mock_redis_service.add_user_to_group(group["id"], user["name"])
+    mock_redis_service.add_user_to_group(group["id"], "Bob")
+    mock_redis_service.save_group_settlements(
+        [[1, 0, 10.0]],
+        f"settlement-group:{group['id']}",
+    )
+
+    response = client.post(
+        "/telegram/webhook/",
+        data=json.dumps(
+            {
+                "update_id": 1,
+                "message": {
+                    "chat": {"id": 1001, "type": "private", "first_name": "Moein"},
+                    "from": {"id": 1001, "first_name": "Moein"},
+                    "text": "/settlements",
+                },
+            }
+        ),
+        content_type="application/json",
+        headers={"X-Telegram-Bot-Api-Secret-Token": "secret"},
+    )
+
+    assert response.status_code == 200
+    assert "Your open settlements:" in fake_bot.messages[0]["text"]
+    assert "Calgary Trip" in fake_bot.messages[0]["text"]
+    assert "Bob pays Moein $10.00" in fake_bot.messages[0]["text"]
 
 
 def test_telegram_webhook_requires_secret(client, monkeypatch):

--- a/app/tests/test_telegram.py
+++ b/app/tests/test_telegram.py
@@ -47,6 +47,36 @@ class FakeBot:
         )
 
 
+def save_manual_group(mock_redis_service, users=None):
+    return mock_redis_service.save_group(
+        {
+            "name": "P2 Trip",
+            "users": users or ["Moein", "Bob"],
+            "id": "p2-group-id",
+            "created_at": "2026-06-21T00:00:00",
+            "source": "manual",
+        }
+    )
+
+
+def create_telegram_expense(client, init_data, group_id, amount=20):
+    response = client.post(
+        "/telegram/api/expenses/",
+        data=json.dumps(
+            {
+                "group_id": group_id,
+                "name": "Dinner",
+                "amount": amount,
+                "sharers": ["Moein", "Bob"],
+            }
+        ),
+        content_type="application/json",
+        headers=auth_headers(init_data),
+    )
+    assert response.status_code == 201
+    return response.get_json()["saved_expense"]
+
+
 def test_telegram_client_served(client):
     response = client.get("/telegram/")
 
@@ -232,6 +262,118 @@ def test_telegram_expense_creation_uses_authenticated_user(
     assert "Moein added <b>Dinner</b>" in fake_bot.messages[0]["text"]
     button = fake_bot.messages[0]["reply_markup"]["inline_keyboard"][0][0]
     assert button["url"].startswith("https://t.me/chipin_test_bot?start=group_")
+
+
+def test_telegram_expense_update_requires_payer_and_recomputes_settlements(
+    client, monkeypatch, mock_redis_service
+):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", BOT_TOKEN)
+    group = save_manual_group(mock_redis_service)
+    moein_init_data = make_init_data({"id": 1001, "first_name": "Moein"})
+    bob_init_data = make_init_data({"id": 1002, "first_name": "Bob"})
+    expense = create_telegram_expense(client, moein_init_data, group["id"])
+
+    forbidden_response = client.put(
+        f"/telegram/api/expenses/{expense['id']}/",
+        data=json.dumps({"amount": 30}),
+        content_type="application/json",
+        headers=auth_headers(bob_init_data),
+    )
+
+    assert forbidden_response.status_code == 403
+
+    response = client.put(
+        f"/telegram/api/expenses/{expense['id']}/",
+        data=json.dumps(
+            {
+                "name": "Updated Dinner",
+                "amount": 30,
+                "sharers": ["Moein", "Bob"],
+            }
+        ),
+        content_type="application/json",
+        headers=auth_headers(moein_init_data),
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["saved_expense"]["name"] == "Updated Dinner"
+    assert data["saved_expense"]["amount"] == 30.0
+    assert "updated_at" in data["saved_expense"]
+    assert data["group_settlement"] == [["Bob", "Moein", 15.0]]
+
+
+def test_telegram_expense_delete_requires_payer_and_recomputes_settlements(
+    client, monkeypatch, mock_redis_service
+):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", BOT_TOKEN)
+    group = save_manual_group(mock_redis_service)
+    moein_init_data = make_init_data({"id": 1001, "first_name": "Moein"})
+    bob_init_data = make_init_data({"id": 1002, "first_name": "Bob"})
+    expense = create_telegram_expense(client, moein_init_data, group["id"])
+
+    forbidden_response = client.delete(
+        f"/telegram/api/expenses/{expense['id']}/",
+        headers=auth_headers(bob_init_data),
+    )
+
+    assert forbidden_response.status_code == 403
+    assert mock_redis_service.get_expense(expense["id"]) is not None
+
+    response = client.delete(
+        f"/telegram/api/expenses/{expense['id']}/",
+        headers=auth_headers(moein_init_data),
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert mock_redis_service.get_expense(expense["id"]) is None
+    assert data["group_settlement"] == []
+
+
+def test_telegram_mark_settlement_paid_records_history_and_closes_balance(
+    client, monkeypatch, mock_redis_service
+):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", BOT_TOKEN)
+    group = save_manual_group(mock_redis_service)
+    moein_init_data = make_init_data({"id": 1001, "first_name": "Moein"})
+    bob_init_data = make_init_data({"id": 1002, "first_name": "Bob"})
+    create_telegram_expense(client, moein_init_data, group["id"])
+
+    response = client.post(
+        f"/telegram/api/groups/{group['id']}/settlements/paid/",
+        data=json.dumps({"debtor": "Bob", "creditor": "Moein", "amount": 10}),
+        content_type="application/json",
+        headers=auth_headers(bob_init_data),
+    )
+
+    assert response.status_code == 201
+    data = response.get_json()
+    assert data["payment"]["debtor"] == "Bob"
+    assert data["payment"]["creditor"] == "Moein"
+    assert data["payment"]["recorded_by"] == "Bob"
+    assert data["group_settlement"] == []
+    assert data["detail"]["payment_history"] == [data["payment"]]
+
+    duplicate_response = client.post(
+        f"/telegram/api/groups/{group['id']}/settlements/paid/",
+        data=json.dumps({"debtor": "Bob", "creditor": "Moein", "amount": 10}),
+        content_type="application/json",
+        headers=auth_headers(bob_init_data),
+    )
+
+    assert duplicate_response.status_code == 400
+    assert duplicate_response.get_json()["error"] == "Settlement is not open"
+
+    detail_response = client.get(
+        f"/telegram/api/groups/{group['id']}/",
+        headers=auth_headers(moein_init_data),
+    )
+
+    assert detail_response.status_code == 200
+    detail = detail_response.get_json()
+    assert detail["settlements"] == []
+    assert detail["payment_history"][0]["amount"] == 10.0
 
 
 def test_telegram_help_command_lists_commands(client, monkeypatch):

--- a/app/tests/test_telegram.py
+++ b/app/tests/test_telegram.py
@@ -1,0 +1,259 @@
+import hashlib
+import hmac
+import json
+import time
+from urllib.parse import parse_qs, urlencode, urlparse
+
+
+BOT_TOKEN = "123456:test-token"
+
+
+def make_init_data(user, chat=None, auth_date=None, bot_token=BOT_TOKEN):
+    fields = {
+        "auth_date": str(auth_date or int(time.time())),
+        "user": json.dumps(user, separators=(",", ":")),
+    }
+    if chat is not None:
+        fields["chat"] = json.dumps(chat, separators=(",", ":"))
+
+    data_check_string = "\n".join(
+        f"{key}={value}" for key, value in sorted(fields.items())
+    )
+    secret_key = hmac.new(
+        b"WebAppData",
+        bot_token.encode("utf-8"),
+        hashlib.sha256,
+    ).digest()
+    fields["hash"] = hmac.new(
+        secret_key,
+        data_check_string.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+    return urlencode(fields)
+
+
+def auth_headers(init_data):
+    return {"X-Telegram-Init-Data": init_data}
+
+
+def test_telegram_client_served(client):
+    response = client.get("/telegram/")
+
+    assert response.status_code == 200
+    assert b"ChipIn" in response.data
+
+
+def test_telegram_client_adds_trailing_slash(client):
+    response = client.get("/telegram")
+
+    assert response.status_code == 308
+    assert response.headers["Location"].endswith("/telegram/")
+
+
+def test_telegram_auth_valid_init_data_upserts_user(client, monkeypatch):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", BOT_TOKEN)
+    init_data = make_init_data(
+        {"id": 1001, "first_name": "Moein", "username": "moein"}
+    )
+
+    response = client.post(
+        "/telegram/auth/",
+        data=json.dumps({"init_data": init_data}),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["user"]["name"] == "Moein"
+    assert data["user"]["telegram_id"] == "1001"
+    assert data["groups"] == []
+
+
+def test_telegram_auth_rejects_tampered_init_data(client, monkeypatch):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", BOT_TOKEN)
+    init_data = make_init_data({"id": 1001, "first_name": "Moein"})
+    tampered = init_data.replace("Moein", "Other")
+
+    response = client.post(
+        "/telegram/auth/",
+        data=json.dumps({"init_data": tampered}),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 401
+    assert response.get_json()["error"] == "Invalid Telegram hash"
+
+
+def test_telegram_auth_creates_group_from_chat_and_self_joins(client, monkeypatch):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", BOT_TOKEN)
+    init_data = make_init_data(
+        {"id": 1001, "first_name": "Moein"},
+        {"id": -2001, "type": "group", "title": "Calgary Trip"},
+    )
+
+    response = client.post(
+        "/telegram/auth/",
+        data=json.dumps({"init_data": init_data}),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["launch_group"]["name"] == "Calgary Trip"
+    assert data["launch_group"]["source"] == "telegram"
+    assert data["launch_group"]["telegram_chat_id"] == "-2001"
+    assert data["launch_group"]["users"] == ["Moein"]
+    assert data["groups"][0]["id"] == data["launch_group"]["id"]
+
+
+def test_telegram_expense_creation_uses_authenticated_user(
+    client, monkeypatch, mock_redis_service
+):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", BOT_TOKEN)
+    init_data = make_init_data(
+        {"id": 1001, "first_name": "Moein"},
+        {"id": -2001, "type": "group", "title": "Calgary Trip"},
+    )
+    auth_response = client.post(
+        "/telegram/auth/",
+        data=json.dumps({"init_data": init_data}),
+        content_type="application/json",
+    )
+    group = auth_response.get_json()["launch_group"]
+
+    bob = mock_redis_service.save_user(
+        {
+            "name": "Bob",
+            "email": "bob@example.com",
+            "id": "bob-id",
+            "created_at": "2026-06-21T00:00:00",
+        }
+    )
+    mock_redis_service.add_user_to_group(group["id"], bob["name"])
+
+    response = client.post(
+        "/telegram/api/expenses/",
+        data=json.dumps(
+            {
+                "group_id": group["id"],
+                "name": "Dinner",
+                "amount": 20,
+                "sharers": ["Moein", "Bob"],
+            }
+        ),
+        content_type="application/json",
+        headers=auth_headers(init_data),
+    )
+
+    assert response.status_code == 201
+    data = response.get_json()
+    assert data["saved_expense"]["payer"] == "Moein"
+    assert data["saved_expense"]["group"] == "Calgary Trip"
+    assert data["group_settlement"] == [["Bob", "Moein", 10.0]]
+
+
+def test_telegram_webhook_requires_secret(client, monkeypatch):
+    monkeypatch.setenv("TELEGRAM_WEBHOOK_SECRET", "secret")
+
+    response = client.post(
+        "/telegram/webhook/",
+        data=json.dumps({"update_id": 1}),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 403
+
+
+def test_telegram_webhook_links_group_and_sends_button(client, monkeypatch):
+    import routes.telegram as telegram_module
+
+    class FakeBot:
+        def __init__(self):
+            self.messages = []
+
+        def send_message(self, chat_id, text, reply_markup=None):
+            self.messages.append(
+                {"chat_id": chat_id, "text": text, "reply_markup": reply_markup}
+            )
+
+    fake_bot = FakeBot()
+    monkeypatch.setenv("TELEGRAM_WEBHOOK_SECRET", "secret")
+    monkeypatch.setenv("PUBLIC_BASE_URL", "https://chipin.example")
+    monkeypatch.setenv("TELEGRAM_BOT_USERNAME", "chipin_test_bot")
+    monkeypatch.setattr(telegram_module, "telegram_bot_client", fake_bot)
+
+    response = client.post(
+        "/telegram/webhook/",
+        data=json.dumps(
+            {
+                "update_id": 1,
+                "message": {
+                    "chat": {"id": -2001, "type": "group", "title": "Calgary Trip"},
+                    "from": {"id": 1001, "first_name": "Moein"},
+                    "text": "/chipin",
+                },
+            }
+        ),
+        content_type="application/json",
+        headers={"X-Telegram-Bot-Api-Secret-Token": "secret"},
+    )
+
+    assert response.status_code == 200
+    assert len(fake_bot.messages) == 1
+    assert fake_bot.messages[0]["chat_id"] == -2001
+    button = fake_bot.messages[0]["reply_markup"]["inline_keyboard"][0][0]
+    parsed_url = urlparse(button["url"])
+    assert f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}" == (
+        "https://t.me/chipin_test_bot"
+    )
+    assert parse_qs(parsed_url.query)["start"][0].startswith("group_")
+
+
+def test_telegram_private_start_payload_joins_group_and_sends_web_app(
+    client, monkeypatch, mock_redis_service
+):
+    import routes.telegram as telegram_module
+
+    class FakeBot:
+        def __init__(self):
+            self.messages = []
+
+        def send_message(self, chat_id, text, reply_markup=None):
+            self.messages.append(
+                {"chat_id": chat_id, "text": text, "reply_markup": reply_markup}
+            )
+
+    fake_bot = FakeBot()
+    group = mock_redis_service.ensure_telegram_group(
+        {"id": -2001, "type": "group", "title": "Calgary Trip"}
+    )
+    monkeypatch.setenv("TELEGRAM_WEBHOOK_SECRET", "secret")
+    monkeypatch.setenv("PUBLIC_BASE_URL", "https://chipin.example")
+    monkeypatch.setattr(telegram_module, "telegram_bot_client", fake_bot)
+
+    response = client.post(
+        "/telegram/webhook/",
+        data=json.dumps(
+            {
+                "update_id": 1,
+                "message": {
+                    "chat": {"id": 1001, "type": "private", "first_name": "Moein"},
+                    "from": {"id": 1001, "first_name": "Moein"},
+                    "text": f"/start group_{group['id']}",
+                },
+            }
+        ),
+        content_type="application/json",
+        headers={"X-Telegram-Bot-Api-Secret-Token": "secret"},
+    )
+
+    assert response.status_code == 200
+    linked_group = mock_redis_service.get_group(group["id"])
+    assert linked_group["users"] == ["Moein"]
+    button = fake_bot.messages[0]["reply_markup"]["inline_keyboard"][0][0]
+    parsed_url = urlparse(button["web_app"]["url"])
+    assert f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}" == (
+        "https://chipin.example/telegram/"
+    )
+    assert parse_qs(parsed_url.query)["group_id"] == [group["id"]]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,10 @@ services:
       - REDIS_PORT=6379
       - REDIS_PASSWORD=mypassword
       - REBUILD_INDEXES=1
+      - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN:-}
+      - TELEGRAM_WEBHOOK_SECRET=${TELEGRAM_WEBHOOK_SECRET:-}
+      - TELEGRAM_BOT_USERNAME=${TELEGRAM_BOT_USERNAME:-}
+      - PUBLIC_BASE_URL=${PUBLIC_BASE_URL:-}
     depends_on:
       - redis
     networks:

--- a/docs/APP_STRUCTURE.md
+++ b/docs/APP_STRUCTURE.md
@@ -20,20 +20,27 @@ chipin/
 │   │   ├── expenses.py
 │   │   ├── groups.py
 │   │   ├── settlements.py
+│   │   ├── telegram.py
 │   │   └── users.py
 │   ├── services/
-│   │   └── redis_service.py
+│   │   ├── redis_service.py
+│   │   ├── telegram_auth.py
+│   │   └── telegram_bot.py
 │   ├── static/
-│   │   └── admin/
+│   │   ├── admin/
+│   │   │   ├── app.js
+│   │   │   ├── chipin-mark.svg
+│   │   │   ├── index.html
+│   │   │   └── styles.css
+│   │   └── telegram/
 │   │       ├── app.js
-│   │       ├── chipin-mark.svg
 │   │       ├── index.html
 │   │       └── styles.css
 │   └── tests/
 │       ├── test_admin.py
 │       ├── conftest.py
-│       ├── test_expenses.py
 │       ├── test_groups.py
+│       ├── test_telegram.py
 │       └── test_users.py
 └── docs/
     ├── APP_STRUCTURE.md
@@ -50,7 +57,7 @@ chipin/
   Builds the application image and installs Python dependencies.
 
 - `app/main.py`:
-  Flask entrypoint. Registers the `users`, `groups`, `expenses`, and `settlements` blueprints, serves the admin panel at `/admin/`, and exposes a small health-style Redis test route.
+  Flask entrypoint. Registers the `users`, `groups`, `expenses`, `settlements`, and `telegram` blueprints, serves the admin panel at `/admin/`, serves the Telegram Mini App at `/telegram/`, and exposes a small health-style Redis test route.
 
 - `app/models/`:
   Domain objects and settlement logic.
@@ -65,12 +72,22 @@ chipin/
   - `groups.py`: create, fetch, and delete groups
   - `expenses.py`: create, fetch, and delete expenses; fetch expenses by group and by payer
   - `settlements.py`: fetch settlements by group, across all groups, and by user involvement
+  - `telegram.py`: Telegram Mini App auth/client API routes and bot webhook handling
 
 - `app/services/redis_service.py`:
   Redis access layer. Handles JSON storage, search indexes, and query helpers for users, groups, expenses, and settlements.
 
+- `app/services/telegram_auth.py`:
+  Validates Telegram Mini App `initData` before the client API trusts a Telegram identity.
+
+- `app/services/telegram_bot.py`:
+  Minimal Telegram Bot API client used by the webhook route to send Mini App buttons and balance replies.
+
 - `app/static/admin/`:
   Static admin panel for creating and viewing users, creating groups and expenses, and viewing balances.
+
+- `app/static/telegram/`:
+  Static Telegram Mini App client for user-facing groups, expenses, balances, and settlements.
 
 - `app/tests/`:
   Pytest-based API tests using a mocked in-memory Redis service.
@@ -78,7 +95,7 @@ chipin/
   - `conftest.py`: shared fixtures and mock service
   - `test_users.py`: user route tests
   - `test_groups.py`: group route tests
-  - `test_expenses.py`: expense route tests
+  - `test_telegram.py`: Telegram auth, Mini App route, group linking, expense creation, and webhook tests
 
 - `app/requirements.txt`:
   Python dependencies for the app and tests.


### PR DESCRIPTION
Adds the Telegram client experience for ChipIn: a bot-launched Mini App with authenticated Telegram users, Telegram-backed groups, group joining, expense creation/edit/delete, settlements, payment history, and bot commands.

- Added Telegram bot webhook and Mini App frontend.
- Added secure Telegram initData validation and Telegram user linking.
- Added Telegram-backed group creation/join flows.
- Added private/group bot commands: /start, /chipin, /help, /groups, /balance, /settlements.
- Added Mini App group detail, expense actions, settlement payment flow, and payment history.
- Added tests for auth, group linking, bot commands, client actions, and settlement payment behavior.
- Added safe local env config and Telegram setup docs.