### PR TITLE
Backfill route and model tests for core flows

### DIFF
--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 import sys
 import os
+import json
 
 # Add backend to path
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
@@ -55,8 +56,11 @@ class MockRedisService:
 
     def delete_group(self, group_id):
         key = f"group:{group_id}"
+        if key not in self.data:
+            return False
+
         self.data.pop(key)
-        return key not in self.data.keys()
+        return True
 
 
 @pytest.fixture
@@ -72,12 +76,50 @@ def client(app):
     return app.test_client()
 
 
+@pytest.fixture
+def create_user(client):
+    """Create a user through the API and return the JSON response."""
+
+    def _create_user(name="User 1", email="user1@example.com"):
+        response = client.post(
+            "/users/",
+            data=json.dumps({"name": name, "email": email}),
+            content_type="application/json",
+        )
+        assert response.status_code == 201
+        return response.get_json()
+
+    return _create_user
+
+
+@pytest.fixture
+def create_group(client, create_user):
+    """Create a group through the API and return the JSON response."""
+
+    def _create_group(name="Group 1", users=None):
+        members = users or ["User 1", "User 2"]
+        for index, member_name in enumerate(members, start=1):
+            create_user(name=member_name, email=f"user{index}@example.com")
+
+        response = client.post(
+            "/groups/",
+            data=json.dumps({"name": name, "users": members}),
+            content_type="application/json",
+        )
+        assert response.status_code == 201
+        return response.get_json()
+
+    return _create_group
+
+
 @pytest.fixture(autouse=True)
 def mock_redis_service(monkeypatch):
     """Replace redis_service with mock for all tests"""
     import services.redis_service as redis_module
     import routes.users as users_module
     import routes.groups as groups_module
+    import routes.expenses as expenses_module
+    import routes.settlements as settlements_module
 
     mock_service = MockRedisService()
 
@@ -85,6 +127,8 @@ def mock_redis_service(monkeypatch):
     monkeypatch.setattr(redis_module, "redis_service", mock_service)
     monkeypatch.setattr(users_module, "redis_service", mock_service)
     monkeypatch.setattr(groups_module, "redis_service", mock_service)
+    monkeypatch.setattr(expenses_module, "redis_service", mock_service)
+    monkeypatch.setattr(settlements_module, "redis_service", mock_service)
 
     yield mock_service
 

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -7,6 +7,7 @@ import json
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from main import app as flask_app
+from models.settlement import Settlement
 
 
 class MockRedisService:
@@ -56,11 +57,113 @@ class MockRedisService:
 
     def delete_group(self, group_id):
         key = f"group:{group_id}"
-        if key not in self.data:
+        group = self.data.get(key)
+        if not group:
+            return False
+
+        expense_keys = [
+            stored_key
+            for stored_key, expense in self.data.items()
+            if stored_key.startswith("expense:") and expense["group"] == group["name"]
+        ]
+        for expense_key in expense_keys:
+            self.data.pop(expense_key)
+
+        self.data.pop(f"settlement-group:{group_id}", None)
+        self.data.pop(key)
+        return True
+
+    def get_group_by_name(self, name):
+        for group in self.get_all_groups():
+            if group["name"] == name:
+                return group
+
+        return None
+
+    # Expense Operations
+    @staticmethod
+    def _expense_summary(expense):
+        return {
+            "id": expense.get("id"),
+            "name": expense.get("name"),
+            "group": expense.get("group"),
+            "amount": expense.get("amount"),
+            "payer": expense.get("payer"),
+            "sharers": expense.get("sharers"),
+        }
+
+    def save_expense(self, expense_dict):
+        key = f"expense:{expense_dict['id']}"
+        self.data[key] = expense_dict
+        return expense_dict
+
+    def get_all_expenses(self):
+        return [v for k, v in self.data.items() if k.startswith("expense:")]
+
+    def get_expense(self, expense_id):
+        key = f"expense:{expense_id}"
+        return self.data.get(key)
+
+    def get_expense_attr(self, expense_id, key):
+        expense = self.get_expense(expense_id)
+        return expense.get(key) if expense else None
+
+    def delete_expense(self, expense_id):
+        key = f"expense:{expense_id}"
+        expense = self.data.get(key)
+        if not expense:
+            return False
+
+        group = self.get_group_by_name(expense["group"])
+        if not group:
             return False
 
         self.data.pop(key)
+
+        group_expenses = self.get_group_expenses(group["id"])
+        tx = Settlement(group_expenses, group["users"])
+        self.save_group_settlements(
+            [list(settlement) for settlement in tx],
+            f"settlement-group:{group['id']}",
+        )
         return True
+
+    def get_group_expenses(self, group_id):
+        group = self.get_group(group_id)
+        if not group:
+            return []
+
+        return [
+            self._expense_summary(expense)
+            for key, expense in self.data.items()
+            if key.startswith("expense:") and expense["group"] == group["name"]
+        ]
+
+    def get_user_paid_expenses(self, user_id):
+        user = self.get_user(user_id)
+        if not user:
+            return []
+
+        return [
+            self._expense_summary(expense)
+            for key, expense in self.data.items()
+            if key.startswith("expense:") and expense["payer"] == user["name"]
+        ]
+
+    # Settlement Operations
+    def save_group_settlements(self, settlement, key):
+        self.data[key] = settlement
+        return settlement
+
+    def get_all_group_settlements(self):
+        return {
+            key: value
+            for key, value in self.data.items()
+            if key.startswith("settlement-group:") and value
+        }
+
+    def get_group_settlements(self, group_id):
+        return self.data.get(f"settlement-group:{group_id}")
 
 
 @pytest.fixture

--- a/app/tests/test_admin.py
+++ b/app/tests/test_admin.py
@@ -5,6 +5,15 @@ def test_admin_panel_served(client):
     assert b"ChipIn Admin" in response.data
 
 
+def test_admin_panel_references_static_assets(client):
+    response = client.get("/admin/")
+
+    assert response.status_code == 200
+    assert b'href="/static/admin/chipin-mark.svg"' in response.data
+    assert b'href="/static/admin/styles.css"' in response.data
+    assert b'src="/static/admin/app.js"' in response.data
+
+
 def test_admin_panel_adds_trailing_slash(client):
     response = client.get("/admin")
 
@@ -17,6 +26,30 @@ def test_admin_panel_assets_served(client):
 
     assert response.status_code == 200
     assert b"refreshData" in response.data
+
+
+def test_admin_stylesheet_served(client):
+    response = client.get("/static/admin/styles.css")
+
+    assert response.status_code == 200
+    assert b".app-shell" in response.data
+
+
+def test_admin_mark_served(client):
+    response = client.get("/static/admin/chipin-mark.svg")
+
+    assert response.status_code == 200
+    assert b"<svg" in response.data
+
+
+def test_admin_script_references_api_routes(client):
+    response = client.get("/static/admin/app.js")
+
+    assert response.status_code == 200
+    assert b'"/users/"' in response.data
+    assert b'"/groups/"' in response.data
+    assert b'"/expenses/"' in response.data
+    assert b'"/settlements/group/"' in response.data
 
 
 def test_client_route_removed(client):

--- a/app/tests/test_expenses.py
+++ b/app/tests/test_expenses.py
@@ -1,0 +1,315 @@
+import json
+
+
+def post_expense(client, payload):
+    return client.post(
+        "/expenses/",
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+
+
+def test_create_expense_with_explicit_sharers(client, create_group):
+    create_group(name="Calgary", users=["Alice", "Bob", "Carol"])
+
+    response = post_expense(
+        client,
+        {
+            "name": "Dinner",
+            "group": "Calgary",
+            "amount": 30,
+            "payer": "Alice",
+            "sharers": ["Alice", "Bob"],
+        },
+    )
+
+    assert response.status_code == 201
+    data = response.get_json()
+    assert data["saved_expense"]["name"] == "Dinner"
+    assert data["saved_expense"]["group"] == "Calgary"
+    assert data["saved_expense"]["amount"] == 30
+    assert data["saved_expense"]["payer"] == "Alice"
+    assert data["saved_expense"]["sharers"] == ["Alice", "Bob"]
+    assert "id" in data["saved_expense"]
+    assert "created_at" in data["saved_expense"]
+    assert data["group_settlement"] == [[1, 0, 15.0]]
+
+
+def test_create_expense_defaults_sharers_to_group_users(client, create_group):
+    create_group(name="Calgary", users=["Alice", "Bob", "Carol"])
+
+    response = post_expense(
+        client,
+        {
+            "name": "Groceries",
+            "group": "Calgary",
+            "amount": 60,
+            "payer": "Alice",
+        },
+    )
+
+    assert response.status_code == 201
+    data = response.get_json()
+    assert data["saved_expense"]["sharers"] == ["Alice", "Bob", "Carol"]
+    assert data["group_settlement"] == [[1, 0, 20.0], [2, 0, 20.0]]
+
+
+def test_create_expense_missing_required_fields(client, create_group):
+    create_group(name="Calgary", users=["Alice", "Bob"])
+
+    required_payload = {
+        "name": "Dinner",
+        "group": "Calgary",
+        "amount": 30,
+        "payer": "Alice",
+    }
+
+    for field in required_payload:
+        payload = required_payload.copy()
+        payload.pop(field)
+
+        response = post_expense(client, payload)
+
+        assert response.status_code == 400
+        assert response.get_json() == {"error": f"Invalid request: missing {field}"}
+
+
+def test_create_expense_group_not_found(client):
+    response = post_expense(
+        client,
+        {
+            "name": "Dinner",
+            "group": "Missing Group",
+            "amount": 30,
+            "payer": "Alice",
+        },
+    )
+
+    assert response.status_code == 404
+    assert response.get_json() == {
+        "error": "Group linked to this expense is not found"
+    }
+
+
+def test_create_expense_payer_not_in_group(client, create_group):
+    create_group(name="Calgary", users=["Alice", "Bob"])
+
+    response = post_expense(
+        client,
+        {
+            "name": "Dinner",
+            "group": "Calgary",
+            "amount": 30,
+            "payer": "Carol",
+        },
+    )
+
+    assert response.status_code == 404
+    assert response.get_json() == {"error": "Payer is not found in the linked Group"}
+
+
+def test_create_expense_sharer_not_in_group(client, create_group):
+    create_group(name="Calgary", users=["Alice", "Bob"])
+
+    response = post_expense(
+        client,
+        {
+            "name": "Dinner",
+            "group": "Calgary",
+            "amount": 30,
+            "payer": "Alice",
+            "sharers": ["Alice", "Carol"],
+        },
+    )
+
+    assert response.status_code == 404
+    assert response.get_json() == {
+        "error": "One or more sharers not found in the linked Group"
+    }
+
+
+def test_get_expenses(client, create_group):
+    create_group(name="Calgary", users=["Alice", "Bob"])
+    post_expense(
+        client,
+        {
+            "name": "Dinner",
+            "group": "Calgary",
+            "amount": 30,
+            "payer": "Alice",
+            "sharers": ["Alice", "Bob"],
+        },
+    )
+    post_expense(
+        client,
+        {
+            "name": "Coffee",
+            "group": "Calgary",
+            "amount": 8,
+            "payer": "Bob",
+            "sharers": ["Alice", "Bob"],
+        },
+    )
+
+    response = client.get("/expenses/")
+
+    assert response.status_code == 200
+    data = response.get_json()
+    expenses_by_name = {expense["name"]: expense for expense in data}
+    assert set(expenses_by_name) == {"Dinner", "Coffee"}
+    assert expenses_by_name["Dinner"]["payer"] == "Alice"
+    assert expenses_by_name["Coffee"]["payer"] == "Bob"
+
+
+def test_get_expense_and_attr(client, create_group):
+    create_group(name="Calgary", users=["Alice", "Bob"])
+    create_response = post_expense(
+        client,
+        {
+            "name": "Dinner",
+            "group": "Calgary",
+            "amount": 30,
+            "payer": "Alice",
+            "sharers": ["Alice", "Bob"],
+        },
+    )
+    expense = create_response.get_json()["saved_expense"]
+
+    response = client.get(f"/expenses/{expense['id']}/")
+
+    assert response.status_code == 200
+    assert response.get_json() == expense
+
+    response = client.get(f"/expenses/{expense['id']}/payer/")
+    assert response.status_code == 200
+    assert response.get_json() == "Alice"
+
+
+def test_get_expense_not_found(client):
+    response = client.get("/expenses/999/")
+
+    assert response.status_code == 404
+    assert response.get_json() == {"error": "Expense not found"}
+
+
+def test_get_expense_attr_not_found(client, create_group):
+    create_group(name="Calgary", users=["Alice", "Bob"])
+    create_response = post_expense(
+        client,
+        {
+            "name": "Dinner",
+            "group": "Calgary",
+            "amount": 30,
+            "payer": "Alice",
+            "sharers": ["Alice", "Bob"],
+        },
+    )
+    expense = create_response.get_json()["saved_expense"]
+
+    response = client.get(f"/expenses/{expense['id']}/missing/")
+
+    assert response.status_code == 404
+    assert response.get_json() == {"error": "Expense or key not found"}
+
+
+def test_get_group_expenses(client, create_group):
+    group = create_group(name="Calgary", users=["Alice", "Bob"])
+    post_expense(
+        client,
+        {
+            "name": "Dinner",
+            "group": "Calgary",
+            "amount": 30,
+            "payer": "Alice",
+            "sharers": ["Alice", "Bob"],
+        },
+    )
+
+    response = client.get(f"/expenses/group/{group['id']}/")
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert len(data) == 1
+    assert data == [
+        {
+            "id": data[0]["id"],
+            "name": "Dinner",
+            "group": "Calgary",
+            "amount": 30,
+            "payer": "Alice",
+            "sharers": ["Alice", "Bob"],
+        }
+    ]
+
+
+def test_get_group_expenses_group_not_found(client):
+    response = client.get("/expenses/group/999/")
+
+    assert response.status_code == 404
+    assert response.get_json() == {"error": "Group not found"}
+
+
+def test_get_user_paid_expenses(client, create_group, mock_redis_service):
+    create_group(name="Calgary", users=["Alice", "Bob"])
+    post_expense(
+        client,
+        {
+            "name": "Dinner",
+            "group": "Calgary",
+            "amount": 30,
+            "payer": "Alice",
+            "sharers": ["Alice", "Bob"],
+        },
+    )
+    alice = next(
+        user
+        for user in mock_redis_service.get_all_users()
+        if user["name"] == "Alice"
+    )
+
+    response = client.get(f"/expenses/user/paid/{alice['id']}/")
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert len(data) == 1
+    assert data[0]["name"] == "Dinner"
+    assert data[0]["payer"] == "Alice"
+
+
+def test_get_user_paid_expenses_user_not_found(client):
+    response = client.get("/expenses/user/paid/999/")
+
+    assert response.status_code == 404
+    assert response.get_json() == {"error": "User not found"}
+
+
+def test_delete_expense(client, create_group):
+    create_group(name="Calgary", users=["Alice", "Bob"])
+    create_response = post_expense(
+        client,
+        {
+            "name": "Dinner",
+            "group": "Calgary",
+            "amount": 30,
+            "payer": "Alice",
+            "sharers": ["Alice", "Bob"],
+        },
+    )
+    expense = create_response.get_json()["saved_expense"]
+
+    response = client.delete(f"/expenses/{expense['id']}/")
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "message": f"Expense {expense['id']} deleted successfully"
+    }
+
+    response = client.get(f"/expenses/{expense['id']}/")
+    assert response.status_code == 404
+
+
+def test_delete_expense_not_found(client):
+    response = client.delete("/expenses/999/")
+
+    assert response.status_code == 404
+    assert response.get_json() == {"error": "Expense not found"}

--- a/app/tests/test_groups.py
+++ b/app/tests/test_groups.py
@@ -23,7 +23,7 @@ def test_create_group(client):
     )
 
     assert response.status_code == 201
-    data = json.loads(response.data)
+    data = response.get_json()
     assert data["name"] == "Calgary"
     assert data["users"] == ["agha vakili", "Moein"]
     assert "id" in data
@@ -52,8 +52,8 @@ def test_create_group_missing_fields(client):
     )
 
     assert response.status_code == 400
-    data = json.loads(response.data)
-    assert "error" in data
+    data = response.get_json()
+    assert data == {"error": "Invalid request: missing name or users"}
 
 
 def test_create_group_missing_users(client):
@@ -67,8 +67,7 @@ def test_create_group_missing_users(client):
     )
 
     assert response.status_code == 400
-    data = json.loads(response.data)
-    assert "error" in data
+    data = response.get_json()
     assert data["error"] == "Invalid request: missing name or users"
 
     # Create a group with users missing in data
@@ -79,8 +78,7 @@ def test_create_group_missing_users(client):
     )
 
     assert response.status_code == 400
-    data = json.loads(response.data)
-    assert "error" in data
+    data = response.get_json()
     assert data["error"] == "Invalid request: missing name or users"
 
 
@@ -101,8 +99,7 @@ def test_create_group_user_not_found(client):
     )
 
     assert response.status_code == 404
-    data = json.loads(response.data)
-    assert "error" in data
+    data = response.get_json()
     assert data["error"] == "One or more names not found"
 
 
@@ -149,17 +146,17 @@ def test_get_groups(client):
     )
     response = client.get("/groups/")
     assert response.status_code == 200
-    data = json.loads(response.data)
+    data = response.get_json()
     assert isinstance(data, list)
     assert len(data) == 2
-    assert data[0]["name"] == "Calgary"
-    assert data[0]["users"] == ["agha vakili", "Moein"]
-    assert "id" in data[0]
-    assert "created_at" in data[0]
-    assert data[1]["name"] == "Vancouver"
-    assert data[1]["users"] == ["User 1", "User 2", "User 3"]
-    assert "id" in data[1]
-    assert "created_at" in data[1]
+    groups_by_name = {group["name"]: group for group in data}
+    assert set(groups_by_name) == {"Calgary", "Vancouver"}
+    assert groups_by_name["Calgary"]["users"] == ["agha vakili", "Moein"]
+    assert "id" in groups_by_name["Calgary"]
+    assert "created_at" in groups_by_name["Calgary"]
+    assert groups_by_name["Vancouver"]["users"] == ["User 1", "User 2", "User 3"]
+    assert "id" in groups_by_name["Vancouver"]
+    assert "created_at" in groups_by_name["Vancouver"]
 
 
 def test_get_group(client):
@@ -183,12 +180,12 @@ def test_get_group(client):
         content_type="application/json",
     )
     assert response.status_code == 201
-    data = json.loads(response.data)
+    data = response.get_json()
 
     # Get the group
     response = client.get(f"/groups/{data['id']}/")
     assert response.status_code == 200
-    data = json.loads(response.data)
+    data = response.get_json()
     assert data["name"] == "Calgary"
     assert data["users"] == ["agha vakili", "Moein"]
     assert "id" in data
@@ -215,7 +212,7 @@ def test_get_group_adds_trailing_slash(client):
         content_type="application/json",
     )
     assert response.status_code == 201
-    data = json.loads(response.data)
+    data = response.get_json()
 
     response = client.get(f"/groups/{data['id']}")
 
@@ -229,8 +226,31 @@ def test_get_group_not_found(client):
     # Get the group
     response = client.get("/groups/999/")
     assert response.status_code == 404
-    data = json.loads(response.data)
-    assert "error" in data
+    data = response.get_json()
+    assert data == {"error": "Group not found"}
+
+
+def test_delete_group(client, create_group):
+    """Test deleting an existing group"""
+    group = create_group(name="Calgary", users=["agha vakili", "Moein"])
+
+    response = client.delete(f"/groups/{group['id']}/")
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data == {"message": f"Group {group['id']} deleted successfully"}
+
+    response = client.get(f"/groups/{group['id']}/")
+    assert response.status_code == 404
+
+
+def test_delete_group_not_found(client):
+    """Test deleting a group that does not exist"""
+    response = client.delete("/groups/999/")
+
+    assert response.status_code == 404
+    data = response.get_json()
+    assert data == {"error": "Group not found"}
 
 
 def test_get_group_attr(client):
@@ -254,7 +274,7 @@ def test_get_group_attr(client):
         content_type="application/json",
     )
     assert response.status_code == 201
-    data = json.loads(response.data)
+    data = response.get_json()
 
     # Get the group's attributes
     for k in ["name", "users"]:

--- a/app/tests/test_main.py
+++ b/app/tests/test_main.py
@@ -1,0 +1,14 @@
+def test_home_api_metadata(client):
+    response = client.get("/")
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["message"] == "ChipIn API"
+    assert data["status"] == "running"
+    assert data["endpoints"] == {
+        "users": "/users",
+        "groups": "/groups",
+        "expenses": "/expenses",
+        "settlements": "/settlements",
+        "admin": "/admin/",
+    }

--- a/app/tests/test_models.py
+++ b/app/tests/test_models.py
@@ -1,0 +1,94 @@
+from models.expense import Expense
+from models.group import Group
+from models.user import User
+
+
+def test_user_to_dict_includes_expected_fields():
+    user = User(name="Alice", email="alice@example.com", uid="user-1")
+
+    data = user.to_dict()
+
+    assert data["name"] == "Alice"
+    assert data["email"] == "alice@example.com"
+    assert data["id"] == "user-1"
+    assert "created_at" in data
+
+
+def test_user_from_dict_preserves_identity_fields():
+    user = User.from_dict(
+        {
+            "name": "Alice",
+            "email": "alice@example.com",
+            "id": "user-1",
+        }
+    )
+
+    assert user.name == "Alice"
+    assert user.email == "alice@example.com"
+    assert user.uid == "user-1"
+
+
+def test_group_to_dict_includes_expected_fields():
+    group = Group(name="Calgary", users=["Alice", "Bob"], uid="group-1")
+
+    data = group.to_dict()
+
+    assert data["name"] == "Calgary"
+    assert data["users"] == ["Alice", "Bob"]
+    assert data["id"] == "group-1"
+    assert "created_at" in data
+
+
+def test_group_from_dict_preserves_identity_fields():
+    group = Group.from_dict(
+        {
+            "name": "Calgary",
+            "users": ["Alice", "Bob"],
+            "id": "group-1",
+        }
+    )
+
+    assert group.name == "Calgary"
+    assert group.users == ["Alice", "Bob"]
+    assert group.uid == "group-1"
+
+
+def test_expense_to_dict_includes_expected_fields():
+    expense = Expense(
+        name="Dinner",
+        group="Calgary",
+        amount=30,
+        payer="Alice",
+        sharers=["Alice", "Bob"],
+        uid="expense-1",
+    )
+
+    data = expense.to_dict()
+
+    assert data["name"] == "Dinner"
+    assert data["group"] == "Calgary"
+    assert data["amount"] == 30
+    assert data["payer"] == "Alice"
+    assert data["sharers"] == ["Alice", "Bob"]
+    assert data["id"] == "expense-1"
+    assert "created_at" in data
+
+
+def test_expense_from_dict_preserves_identity_fields():
+    expense = Expense.from_dict(
+        {
+            "name": "Dinner",
+            "group": "Calgary",
+            "amount": 30,
+            "payer": "Alice",
+            "sharers": ["Alice", "Bob"],
+            "id": "expense-1",
+        }
+    )
+
+    assert expense.name == "Dinner"
+    assert expense.group == "Calgary"
+    assert expense.amount == 30
+    assert expense.payer == "Alice"
+    assert expense.sharers == ["Alice", "Bob"]
+    assert expense.uid == "expense-1"

--- a/app/tests/test_redis_service.py
+++ b/app/tests/test_redis_service.py
@@ -1,0 +1,42 @@
+from services.redis_service import RedisService
+
+
+def test_escape_tag_value_escapes_redisearch_special_characters():
+    assert RedisService._escape_tag_value("Alice Bob") == "Alice\\ Bob"
+    assert RedisService._escape_tag_value("a,b@example.com") == (
+        "a\\,b\\@example\\.com"
+    )
+    assert RedisService._escape_tag_value("Group-1") == "Group\\-1"
+
+
+def test_expense_summary_returns_public_expense_fields_only():
+    expense = {
+        "id": "expense-1",
+        "name": "Dinner",
+        "group": "Calgary",
+        "amount": 30,
+        "payer": "Alice",
+        "sharers": ["Alice", "Bob"],
+        "created_at": "2026-06-21T00:00:00",
+        "internal": "ignored",
+    }
+
+    assert RedisService._expense_summary(expense) == {
+        "id": "expense-1",
+        "name": "Dinner",
+        "group": "Calgary",
+        "amount": 30,
+        "payer": "Alice",
+        "sharers": ["Alice", "Bob"],
+    }
+
+
+def test_expense_summary_uses_none_for_missing_public_fields():
+    assert RedisService._expense_summary({"id": "expense-1"}) == {
+        "id": "expense-1",
+        "name": None,
+        "group": None,
+        "amount": None,
+        "payer": None,
+        "sharers": None,
+    }

--- a/app/tests/test_settlement_model.py
+++ b/app/tests/test_settlement_model.py
@@ -1,0 +1,66 @@
+import pytest
+
+from models.settlement import Settlement
+
+
+def test_settlement_with_no_expenses_returns_empty_list():
+    assert Settlement([], ["Alice", "Bob"]) == []
+
+
+def test_settlement_splits_one_expense_between_two_users():
+    expenses = [
+        {
+            "amount": 20,
+            "payer": "Alice",
+            "sharers": ["Alice", "Bob"],
+        }
+    ]
+
+    assert Settlement(expenses, ["Alice", "Bob"]) == [(1, 0, pytest.approx(10))]
+
+
+def test_settlement_splits_one_expense_among_three_users():
+    expenses = [
+        {
+            "amount": 30,
+            "payer": "Alice",
+            "sharers": ["Alice", "Bob", "Carol"],
+        }
+    ]
+
+    assert Settlement(expenses, ["Alice", "Bob", "Carol"]) == [
+        (1, 0, pytest.approx(10)),
+        (2, 0, pytest.approx(10)),
+    ]
+
+
+def test_settlement_offsets_multiple_expenses():
+    expenses = [
+        {
+            "amount": 20,
+            "payer": "Alice",
+            "sharers": ["Alice", "Bob"],
+        },
+        {
+            "amount": 8,
+            "payer": "Bob",
+            "sharers": ["Alice", "Bob"],
+        },
+    ]
+
+    assert Settlement(expenses, ["Alice", "Bob"]) == [(1, 0, pytest.approx(6))]
+
+
+def test_settlement_applies_existing_transaction_history():
+    expenses = [
+        {
+            "amount": 8,
+            "payer": "Bob",
+            "sharers": ["Alice", "Bob"],
+        }
+    ]
+    tx_hist = [(1, 0, 10)]
+
+    assert Settlement(expenses, ["Alice", "Bob"], tx_hist) == [
+        (1, 0, pytest.approx(6))
+    ]

--- a/app/tests/test_settlements.py
+++ b/app/tests/test_settlements.py
@@ -1,0 +1,143 @@
+import json
+
+
+def post_expense(client, payload):
+    return client.post(
+        "/expenses/",
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+
+
+def user_by_name(mock_redis_service, name):
+    return next(
+        user
+        for user in mock_redis_service.get_all_users()
+        if user["name"] == name
+    )
+
+
+def test_get_all_group_settlements(client, create_group):
+    group = create_group(name="Calgary", users=["Alice", "Bob"])
+    post_expense(
+        client,
+        {
+            "name": "Dinner",
+            "group": "Calgary",
+            "amount": 20,
+            "payer": "Alice",
+            "sharers": ["Alice", "Bob"],
+        },
+    )
+
+    response = client.get("/settlements/group/")
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        f"settlement-group:{group['id']}": [["Bob", "Alice", 10.0]]
+    }
+
+
+def test_get_group_settlements_from_stored_history(client, create_group):
+    group = create_group(name="Calgary", users=["Alice", "Bob"])
+    post_expense(
+        client,
+        {
+            "name": "Dinner",
+            "group": "Calgary",
+            "amount": 20,
+            "payer": "Alice",
+            "sharers": ["Alice", "Bob"],
+        },
+    )
+
+    response = client.get(f"/settlements/group/{group['id']}/")
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "settlements_this_group": [["Bob", "Alice", 10.0]]
+    }
+
+
+def test_get_group_settlements_computes_from_expenses_without_history(
+    client, create_group, mock_redis_service
+):
+    group = create_group(name="Calgary", users=["Alice", "Bob"])
+    mock_redis_service.save_expense(
+        {
+            "id": "expense-1",
+            "name": "Dinner",
+            "group": "Calgary",
+            "amount": 20,
+            "payer": "Alice",
+            "sharers": ["Alice", "Bob"],
+            "created_at": "2026-06-21T00:00:00",
+        }
+    )
+
+    response = client.get(f"/settlements/group/{group['id']}/")
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "settlements_this_group": [["Bob", "Alice", 10.0]]
+    }
+
+
+def test_get_group_settlements_with_no_expenses(client, create_group):
+    group = create_group(name="Calgary", users=["Alice", "Bob"])
+
+    response = client.get(f"/settlements/group/{group['id']}/")
+
+    assert response.status_code == 404
+    assert response.get_json() == {
+        "warning": "There are no expenses linked to this group"
+    }
+
+
+def test_get_group_settlements_group_not_found(client):
+    response = client.get("/settlements/group/999/")
+
+    assert response.status_code == 404
+    assert response.get_json() == {"error": "Group and its settlements not found"}
+
+
+def test_get_user_settlements_merges_across_groups(
+    client, create_group, mock_redis_service
+):
+    create_group(name="Calgary", users=["Alice", "Bob"])
+    post_expense(
+        client,
+        {
+            "name": "Dinner",
+            "group": "Calgary",
+            "amount": 20,
+            "payer": "Alice",
+            "sharers": ["Alice", "Bob"],
+        },
+    )
+    create_group(name="Vancouver", users=["Alice", "Bob"])
+    post_expense(
+        client,
+        {
+            "name": "Coffee",
+            "group": "Vancouver",
+            "amount": 8,
+            "payer": "Bob",
+            "sharers": ["Alice", "Bob"],
+        },
+    )
+    alice = user_by_name(mock_redis_service, "Alice")
+
+    response = client.get(f"/settlements/user/{alice['id']}/")
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "settlements_this_user": [["Bob", "Alice", 6.0]]
+    }
+
+
+def test_get_user_settlements_user_not_found(client):
+    response = client.get("/settlements/user/999/")
+
+    assert response.status_code == 404
+    assert response.get_json() == {"error": "User not found"}

--- a/app/tests/test_users.py
+++ b/app/tests/test_users.py
@@ -10,7 +10,7 @@ def test_create_user(client):
     )
 
     assert response.status_code == 201
-    data = json.loads(response.data)
+    data = response.get_json()
     assert data["name"] == "agha vakili"
     assert data["email"] == "mjvk@example.com"
     assert "id" in data
@@ -26,8 +26,8 @@ def test_create_user_missing_fields(client):
     )
 
     assert response.status_code == 400
-    data = json.loads(response.data)
-    assert "error" in data
+    data = response.get_json()
+    assert data == {"error": "Invalid request: missing name or email"}
 
 
 def test_get_users(client):
@@ -45,17 +45,17 @@ def test_get_users(client):
     )
     response = client.get("/users/")
     assert response.status_code == 200
-    data = json.loads(response.data)
+    data = response.get_json()
     assert isinstance(data, list)
     assert len(data) == 2
-    assert data[0]["name"] == "User 1"
-    assert data[0]["email"] == "user1@example.com"
-    assert "id" in data[0]
-    assert "created_at" in data[0]
-    assert data[1]["name"] == "User 2"
-    assert data[1]["email"] == "user2@example.com"
-    assert "id" in data[1]
-    assert "created_at" in data[1]
+    users_by_name = {user["name"]: user for user in data}
+    assert set(users_by_name) == {"User 1", "User 2"}
+    assert users_by_name["User 1"]["email"] == "user1@example.com"
+    assert "id" in users_by_name["User 1"]
+    assert "created_at" in users_by_name["User 1"]
+    assert users_by_name["User 2"]["email"] == "user2@example.com"
+    assert "id" in users_by_name["User 2"]
+    assert "created_at" in users_by_name["User 2"]
 
 
 def test_get_user(client):
@@ -67,12 +67,12 @@ def test_get_user(client):
         content_type="application/json",
     )
     assert response.status_code == 201
-    data = json.loads(response.data)
+    data = response.get_json()
 
     # Get the user
     response = client.get(f"/users/{data['id']}/")
     assert response.status_code == 200
-    data = json.loads(response.data)
+    data = response.get_json()
     assert data["name"] == "User 1"
     assert data["email"] == "user1@example.com"
     assert "id" in data
@@ -87,7 +87,7 @@ def test_get_user_adds_trailing_slash(client):
         content_type="application/json",
     )
     assert response.status_code == 201
-    data = json.loads(response.data)
+    data = response.get_json()
 
     response = client.get(f"/users/{data['id']}")
 
@@ -101,8 +101,8 @@ def test_get_user_not_found(client):
     # Get the user
     response = client.get("/users/999/")
     assert response.status_code == 404
-    data = json.loads(response.data)
-    assert "error" in data
+    data = response.get_json()
+    assert data == {"error": "User not found"}
 
 
 def test_get_user_names(client):
@@ -114,12 +114,11 @@ def test_get_user_names(client):
         content_type="application/json",
     )
     assert response.status_code == 201
-    data = json.loads(response.data)
 
     # Get the user's names
     response = client.get("/users/user-names/")
     assert response.status_code == 200
-    data = json.loads(response.data)
+    data = response.get_json()
     assert type(data) is list
     assert data[0] == "User 1"
 
@@ -133,11 +132,11 @@ def test_get_user_attr(client):
         content_type="application/json",
     )
     assert response.status_code == 201
-    data = json.loads(response.data)
+    data = response.get_json()
 
     # Get the user's attributes
     for k in ["name", "email"]:
         response = client.get(f"/users/{data['id']}/{k}/")
-        this_data = json.loads(response.data)
+        this_data = response.get_json()
         assert response.status_code == 200
         assert this_data == data[k]

--- a/docs/APP_STRUCTURE.md
+++ b/docs/APP_STRUCTURE.md
@@ -30,10 +30,15 @@ chipin/
 │   │       ├── index.html
 │   │       └── styles.css
 │   └── tests/
-│       ├── test_admin.py
 │       ├── conftest.py
+│       ├── test_admin.py
 │       ├── test_expenses.py
 │       ├── test_groups.py
+│       ├── test_main.py
+│       ├── test_models.py
+│       ├── test_redis_service.py
+│       ├── test_settlement_model.py
+│       ├── test_settlements.py
 │       └── test_users.py
 └── docs/
     ├── APP_STRUCTURE.md
@@ -73,12 +78,17 @@ chipin/
   Static admin panel for creating and viewing users, creating groups and expenses, and viewing balances.
 
 - `app/tests/`:
-  Pytest-based API tests using a mocked in-memory Redis service.
-  - `test_admin.py`: admin panel serving tests
-  - `conftest.py`: shared fixtures and mock service
-  - `test_users.py`: user route tests
-  - `test_groups.py`: group route tests
+  Pytest-based route, unit, and static smoke tests. Route tests use a mocked in-memory Redis service so they run quickly without depending on Redis state.
+  - `conftest.py`: shared Flask app/client fixtures, helpers, and mock Redis service
+  - `test_admin.py`: admin panel and static asset smoke tests
   - `test_expenses.py`: expense route tests
+  - `test_groups.py`: group route tests
+  - `test_main.py`: root API metadata smoke test
+  - `test_models.py`: model serialization unit tests
+  - `test_redis_service.py`: focused Redis service helper unit tests
+  - `test_settlement_model.py`: settlement calculation unit tests
+  - `test_settlements.py`: settlement route tests
+  - `test_users.py`: user route tests
 
 - `app/requirements.txt`:
   Python dependencies for the app and tests.

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -139,18 +139,33 @@ it returns a list of settlements where the user is either the debtor or the cred
 If you just changed the code and want to run tests, you should first rebuild the container:
 ```bash
 # Rebuild with new dependencies
-docker-compose down
-docker-compose up --build -d
+docker compose down
+docker compose up --build -d
 ```
 then run the tests using one of the following commands:
 ```bash
 # Run tests inside container
-docker exec -it chipin-app pytest
+docker exec chipin-app pytest
 
 # Or with more verbose output
-docker exec -it chipin-app pytest -v
+docker exec chipin-app pytest -v
 
 # Run specific test file
-docker exec -it chipin-app pytest tests/test_users.py
+docker exec chipin-app pytest tests/test_users.py
 ```
-**NOTE:** Redis_stack was simulated for the tests so the tests run fast without needing the real Redis container.
+
+Current focused test files:
+
+```bash
+docker exec chipin-app pytest tests/test_admin.py -v
+docker exec chipin-app pytest tests/test_expenses.py -v
+docker exec chipin-app pytest tests/test_groups.py -v
+docker exec chipin-app pytest tests/test_main.py -v
+docker exec chipin-app pytest tests/test_models.py -v
+docker exec chipin-app pytest tests/test_redis_service.py -v
+docker exec chipin-app pytest tests/test_settlement_model.py -v
+docker exec chipin-app pytest tests/test_settlements.py -v
+docker exec chipin-app pytest tests/test_users.py -v
+```
+
+**NOTE:** Most tests use a mocked in-memory Redis service so they run fast without depending on Redis data state. Real Redis Stack integration tests are intentionally deferred for a separate focused pass.

--- a/docs/GET_STARTED_REDIS-STACK.md
+++ b/docs/GET_STARTED_REDIS-STACK.md
@@ -25,10 +25,10 @@ docker exec -it redis-stack redis-cli
 Each expense is stored as a separate JSON document using **RedisJSON**.
 
 ```bash
-JSON.SET expense:1 $ '{"id": "1", "title": "Walmart", "expense": 500, "paid_by": "Alex", "sharers": ["Alex", "Dan", "Joe"], "date": "2024-12-22"}'
-JSON.SET expense:2 $ '{"id": "2", "title": "Airbnb", "expense": 435, "paid_by": "Dan", "sharers": ["Dan", "Joe"], "date": "2024-12-10"}'
-JSON.SET expense:3 $ '{"id": "3", "title": "bar", "expense": 56, "paid_by": "Joe", "sharers": ["Dan", "Joe"], "date": "2024-12-11"}'
-JSON.SET expense:4 $ '{"id": "4", "title": "Car rental", "expense": 189, "paid_by": "Joe", "sharers": ["Alex", "Joe"], "date": "2024-12-16"}'
+JSON.SET expense:1 $ '{"id": "1", "name": "Walmart", "group": "Calgary", "amount": 500, "payer": "Alex", "sharers": ["Alex", "Dan", "Joe"], "created_at": "2026-06-21T00:00:00"}'
+JSON.SET expense:2 $ '{"id": "2", "name": "Airbnb", "group": "Calgary", "amount": 435, "payer": "Dan", "sharers": ["Dan", "Joe"], "created_at": "2026-06-21T00:00:00"}'
+JSON.SET expense:3 $ '{"id": "3", "name": "Bar", "group": "Calgary", "amount": 56, "payer": "Joe", "sharers": ["Dan", "Joe"], "created_at": "2026-06-21T00:00:00"}'
+JSON.SET expense:4 $ '{"id": "4", "name": "Car rental", "group": "Vancouver", "amount": 189, "payer": "Joe", "sharers": ["Alex", "Joe"], "created_at": "2026-06-21T00:00:00"}'
 ```
 
 ---
@@ -39,7 +39,7 @@ Retrieve the full JSON object or a specific field:
 
 ```bash
 JSON.GET expense:2
-JSON.GET expense:2 $.paid_by
+JSON.GET expense:2 $.payer
 ```
 
 ---
@@ -50,11 +50,13 @@ Before querying, create an index using **RediSearch**.
 
 ```bash
 FT.CREATE idx:expense ON JSON PREFIX 1 "expense:" SCHEMA \
-  $.expense     AS expense  NUMERIC SORTABLE \
-  $.paid_by     AS paid_by  TAG \
-  $.sharers[*]  AS sharers  TAG \
-  $.title       AS title    TEXT \
-  $.date        AS date     TAG
+  $.name        AS name        TEXT \
+  $.group       AS group       TAG \
+  $.amount      AS amount      NUMERIC SORTABLE \
+  $.payer       AS payer       TAG \
+  $.sharers[*]  AS sharers     TAG \
+  $.id          AS id          TAG \
+  $.created_at  AS created_at  TEXT
 ```
 
 ---
@@ -63,12 +65,17 @@ FT.CREATE idx:expense ON JSON PREFIX 1 "expense:" SCHEMA \
 
 ### Expenses greater than 300
 ```bash
-FT.SEARCH idx:expense '@expense:[(300 +inf]'
+FT.SEARCH idx:expense '@amount:[(300 +inf]'
 ```
 
 ### Expenses paid by Joe
 ```bash
-FT.SEARCH idx:expense '@paid_by:{Joe}'
+FT.SEARCH idx:expense '@payer:{Joe}'
+```
+
+### Expenses for a group
+```bash
+FT.SEARCH idx:expense '@group:{Calgary}'
 ```
 
 ### Expenses shared with Alex
@@ -90,9 +97,9 @@ docker stop redis-stack
 
 - **Redis Stack** includes both RedisJSON and RediSearch for JSON storage + querying.
 - You can connect this Redis Stack container to a **Flask (Tiangolo) container**.
-- Add a numeric timestamp field (`date_ts`) if you plan to run range queries on dates.
+- The app's route tests use a mocked in-memory Redis service; real Redis Stack integration tests are deferred to a separate focused pass.
+- Add a numeric timestamp field, such as `created_at_ts`, if you plan to run range queries on dates.
 
 ---
 
-**Date:** October 2025
-
+**Date:** June 2026


### PR DESCRIPTION
## Summary

Backfills and modernizes the test suite for the current ChipIn app architecture.

This adds coverage for users, groups, expenses, settlements, model serialization, settlement calculation, Redis service helpers, and admin static serving. It also documents the first-pass test backfill plan and updates docs to reflect the current test layout and commands.

## What Changed

- Expanded the shared pytest harness with reusable helpers and a fuller in-memory Redis mock.
- Added root API metadata smoke coverage.
- Added group delete route coverage.
- Added expense route tests for create/list/detail/filter/delete and validation paths.
- Added settlement route tests for group, all-group, and user settlement lookups.
- Added unit tests for settlement calculation logic.
- Added unit tests for `User`, `Group`, and `Expense` serialization.
- Added focused Redis service helper tests.
- Expanded admin static smoke coverage.
- Added `TEST_BACKFILL_PLAN_FIRST.md`.
- Updated docs for test structure, test commands, and current Redis expense schema.

## Verification

```bash
docker exec chipin-app pytest -v