### PR TITLE
ci: expand automated test coverage and add manual CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,3 +262,90 @@ jobs:
       - name: Stop application stack
         if: always()
         run: docker compose down --volumes
+
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    env:
+      TELEGRAM_BOT_TOKEN: "123456:e2e-test-token"
+      TELEGRAM_WEBHOOK_SECRET: "e2e-webhook-secret"
+      TELEGRAM_BOT_USERNAME: "e2e_test_bot"
+      PUBLIC_BASE_URL: "https://example.com"
+      E2E_BASE_URL: "http://localhost:18080"
+      COMPOSE_FILE: "docker-compose.yml:docker-compose.e2e.yml"
+      COMPOSE_PROJECT_NAME: "chipin-e2e"
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Validate E2E Docker Compose configuration
+        run: docker compose config --quiet
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install end-to-end test dependencies
+        run: |
+          python -m pip install -r e2e/requirements.txt
+          python -m playwright install --with-deps chromium
+
+      - name: Start Redis Stack
+        run: |
+          docker compose up --detach redis
+
+          for attempt in {1..30}; do
+            if docker compose exec --no-TTY redis \
+              redis-cli --no-auth-warning -a mypassword ping | grep --quiet PONG; then
+              exit 0
+            fi
+            sleep 2
+          done
+
+          docker compose ps
+          docker compose logs redis
+          exit 1
+
+      - name: Build and start Flask application
+        run: docker compose up --build --detach app
+
+      - name: Wait for application
+        run: |
+          for attempt in {1..30}; do
+            if curl --fail --silent http://localhost:18080/test-redis/ \
+              | jq --exit-status '.success == true' > /dev/null; then
+              exit 0
+            fi
+            sleep 2
+          done
+
+          docker compose ps
+          docker compose logs app
+          exit 1
+
+      - name: Run browser end-to-end tests
+        run: |
+          cd e2e
+          python -m pytest --output=test-results
+
+      - name: Upload Playwright diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-test-results
+          path: e2e/test-results/
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Show Docker logs on failure
+        if: failure()
+        run: |
+          docker compose ps
+          docker compose logs --tail=200 app redis
+
+      - name: Stop application stack
+        if: always()
+        run: docker compose down --volumes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,10 +84,44 @@ jobs:
           set -euo pipefail
           base_url="http://localhost"
 
+          assert_status() {
+            local expected_status="$1"
+            local method="$2"
+            local path="$3"
+            local body="${4:-}"
+            local actual_status
+
+            if [ -n "$body" ]; then
+              actual_status=$(
+                curl --silent --output /dev/null --write-out '%{http_code}' \
+                  --request "$method" "$base_url$path" \
+                  --header "Content-Type: application/json" \
+                  --data "$body"
+              )
+            else
+              actual_status=$(
+                curl --silent --output /dev/null --write-out '%{http_code}' \
+                  --request "$method" "$base_url$path"
+              )
+            fi
+
+            test "$actual_status" = "$expected_status"
+          }
+
           curl --fail --silent "$base_url/" \
             | jq --exit-status '.status == "running"' > /dev/null
           curl --fail --silent "$base_url/admin/" > /dev/null
           curl --fail --silent "$base_url/telegram/" > /dev/null
+          curl --fail --silent "$base_url/users/" \
+            | jq --exit-status 'type == "array" and length == 0' > /dev/null
+          curl --fail --silent "$base_url/groups/" \
+            | jq --exit-status 'type == "array" and length == 0' > /dev/null
+          curl --fail --silent "$base_url/expenses/" \
+            | jq --exit-status 'type == "array" and length == 0' > /dev/null
+          assert_status 400 POST /users/ '{"name":"Missing Email"}'
+          assert_status 404 GET /users/not-found/
+          assert_status 404 POST /groups/ \
+            '{"name":"Invalid Group","users":["Unknown"]}'
 
           alice=$(
             curl --fail-with-body --silent \
@@ -104,6 +138,15 @@ jobs:
           alice_id=$(jq --exit-status --raw-output '.id' <<< "$alice")
           bob_id=$(jq --exit-status --raw-output '.id' <<< "$bob")
 
+          curl --fail --silent "$base_url/users/" \
+            | jq --exit-status \
+                'length == 2 and any(.[]; .name == "Alice") and any(.[]; .name == "Bob")' > /dev/null
+          curl --fail --silent "$base_url/users/user-names/" \
+            | jq --exit-status \
+                'length == 2 and index("Alice") and index("Bob")' > /dev/null
+          curl --fail --silent "$base_url/users/$alice_id/name/" \
+            | jq --exit-status '. == "Alice"' > /dev/null
+
           group=$(
             curl --fail-with-body --silent \
               --request POST "$base_url/groups/" \
@@ -111,6 +154,20 @@ jobs:
               --data '{"name":"CI Group","users":["Alice","Bob"]}'
           )
           group_id=$(jq --exit-status --raw-output '.id' <<< "$group")
+
+          curl --fail --silent "$base_url/groups/" \
+            | jq --exit-status \
+                'length == 1 and .[0].name == "CI Group"' > /dev/null
+          curl --fail --silent "$base_url/groups/$group_id/name/" \
+            | jq --exit-status '. == "CI Group"' > /dev/null
+          assert_status 400 POST /expenses/ \
+            '{"name":"Missing Payer","group":"CI Group","amount":30}'
+          assert_status 404 POST /expenses/ \
+            '{"name":"Bad Group","group":"Unknown","amount":30,"payer":"Alice"}'
+          assert_status 404 POST /expenses/ \
+            '{"name":"Bad Payer","group":"CI Group","amount":30,"payer":"Charlie"}'
+          assert_status 404 POST /expenses/ \
+            '{"name":"Bad Sharer","group":"CI Group","amount":30,"payer":"Alice","sharers":["Alice","Charlie"]}'
 
           expense=$(
             curl --fail-with-body --silent \
@@ -124,6 +181,19 @@ jobs:
           jq --exit-status \
             '.group_settlement == [[1, 0, 15]]' <<< "$expense" > /dev/null
 
+          snacks=$(
+            curl --fail-with-body --silent \
+              --request POST "$base_url/expenses/" \
+              --header "Content-Type: application/json" \
+              --data '{"name":"Snacks","group":"CI Group","amount":10,"payer":"Bob"}'
+          )
+          snacks_id=$(
+            jq --exit-status --raw-output '.saved_expense.id' <<< "$snacks"
+          )
+          jq --exit-status \
+            '.saved_expense.sharers == ["Alice", "Bob"] and .group_settlement == [[1, 0, 10]]' \
+            <<< "$snacks" > /dev/null
+
           curl --fail --silent "$base_url/users/$alice_id/" \
             | jq --exit-status '.name == "Alice"' > /dev/null
           curl --fail --silent "$base_url/users/$bob_id/" \
@@ -134,27 +204,59 @@ jobs:
           curl --fail --silent "$base_url/expenses/$expense_id/" \
             | jq --exit-status \
                 '.name == "Dinner" and .amount == 30' > /dev/null
+          curl --fail --silent "$base_url/expenses/$expense_id/payer/" \
+            | jq --exit-status '. == "Alice"' > /dev/null
+          curl --fail --silent "$base_url/expenses/" \
+            | jq --exit-status \
+                'length == 2 and any(.[]; .name == "Dinner") and any(.[]; .name == "Snacks")' > /dev/null
           curl --fail --silent "$base_url/expenses/group/$group_id/" \
             | jq --exit-status \
-                'length == 1 and .[0].name == "Dinner"' > /dev/null
+                'length == 2 and any(.[]; .name == "Dinner") and any(.[]; .name == "Snacks")' > /dev/null
           curl --fail --silent "$base_url/expenses/user/paid/$alice_id/" \
             | jq --exit-status \
                 'length == 1 and .[0].payer == "Alice"' > /dev/null
+          curl --fail --silent "$base_url/expenses/user/paid/$bob_id/" \
+            | jq --exit-status \
+                'length == 1 and .[0].payer == "Bob"' > /dev/null
+          curl --fail --silent "$base_url/settlements/group/" \
+            | jq --exit-status \
+                'to_entries | length == 1 and .[0].value == [["Bob", "Alice", 10]]' > /dev/null
           curl --fail --silent "$base_url/settlements/group/$group_id/" \
             | jq --exit-status \
-                '.settlements_this_group == [["Bob", "Alice", 15]]' > /dev/null
+                '.settlements_this_group == [["Bob", "Alice", 10]]' > /dev/null
           curl --fail --silent "$base_url/settlements/user/$bob_id/" \
             | jq --exit-status \
-                '.settlements_this_user == [["Bob", "Alice", 15]]' > /dev/null
+                '.settlements_this_user == [["Bob", "Alice", 10]]' > /dev/null
+          assert_status 404 GET /expenses/not-found/
+          assert_status 404 GET /expenses/group/not-found/
+          assert_status 404 GET /expenses/user/paid/not-found/
+          assert_status 404 GET /settlements/group/not-found/
+          assert_status 404 GET /settlements/user/not-found/
+          assert_status 404 DELETE /expenses/not-found/
 
           curl --fail-with-body --silent \
             --request DELETE "$base_url/expenses/$expense_id/" > /dev/null
+          test "$(
+            curl --silent --output /dev/null --write-out '%{http_code}' \
+              "$base_url/expenses/$expense_id/"
+          )" = "404"
+          curl --fail --silent "$base_url/expenses/group/$group_id/" \
+            | jq --exit-status \
+                'length == 1 and .[0].name == "Snacks"' > /dev/null
+          curl --fail --silent "$base_url/settlements/group/$group_id/" \
+            | jq --exit-status \
+                '.settlements_this_group == [["Alice", "Bob", 5]]' > /dev/null
+
           curl --fail-with-body --silent \
             --request DELETE "$base_url/groups/$group_id/" > /dev/null
 
           test "$(
             curl --silent --output /dev/null --write-out '%{http_code}' \
               "$base_url/groups/$group_id/"
+          )" = "404"
+          test "$(
+            curl --silent --output /dev/null --write-out '%{http_code}' \
+              "$base_url/expenses/$snacks_id/"
           )" = "404"
 
       - name: Stop application stack

--- a/.github/workflows/manual-cd.yml
+++ b/.github/workflows/manual-cd.yml
@@ -1,0 +1,64 @@
+name: Manual CD
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: manual-cd
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy app on server
+    runs-on: self-hosted
+    timeout-minutes: 15
+
+    env:
+      SERVER_APP_DIR: ${{ vars.SERVER_APP_DIR }}
+
+    steps:
+      - name: Deploy latest main
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -z "${SERVER_APP_DIR:-}" ]; then
+            echo "SERVER_APP_DIR repository variable is not set."
+            echo "Set it to the absolute path of the ChipIn repo on the deployment server."
+            exit 1
+          fi
+
+          cd "$SERVER_APP_DIR"
+
+          git fetch origin
+          git checkout main
+          git pull --ff-only origin main
+
+          docker compose build app
+          docker compose up -d --no-deps app
+
+      - name: Verify app health
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          cd "$SERVER_APP_DIR"
+
+          for attempt in {1..30}; do
+            if curl --fail --silent --show-error http://localhost/ \
+              | grep --quiet '"status"[[:space:]]*:[[:space:]]*"running"'; then
+              echo "Manual CD health check passed."
+              exit 0
+            fi
+
+            echo "Waiting for app health check... attempt $attempt/30"
+            sleep 2
+          done
+
+          echo "Manual CD health check failed."
+          docker compose ps
+          docker compose logs --tail=200 app
+          exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
 # Dir
 redis-data/
 __pycache__/
+.pytest_cache/
 .DS_Store
 actions-runner/
+e2e/test-results/
+.venv/
 
 # Local secrets/config
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 redis-data/
 __pycache__/
 .DS_Store
+actions-runner/
 
 # Local secrets/config
 .env

--- a/README.md
+++ b/README.md
@@ -82,6 +82,54 @@ GitHub Actions runs the workflow in [`.github/workflows/ci.yml`](.github/workflo
 
 When both jobs are configured as required status checks in the `main` branch ruleset, GitHub blocks merging until they pass.
 
+## Manual CD
+
+Manual deployment is handled by [`.github/workflows/manual-cd.yml`](.github/workflows/manual-cd.yml). This workflow is intentionally not automatic: it only runs when someone clicks **Run workflow** in GitHub Actions.
+
+The deployment job uses a GitHub self-hosted runner installed on the deployment server. This avoids exposing SSH and lets the deployment commands run locally on the same machine that already runs Docker Compose, Redis Stack, the Flask app, and ngrok.
+
+### One-time server setup
+
+On GitHub, open the repository and go to **Settings → Actions → Runners → New self-hosted runner**. Choose the server's operating system and follow GitHub's generated setup commands on the server.
+
+After registering the runner:
+
+- keep the runner running on the server, ideally as a service
+- make sure the runner user can run `git`, `docker`, and `docker compose`
+- make sure the runner user has Docker permission, for example by being in the `docker` group on Linux
+- make sure the ChipIn repo already exists on the server
+
+Set this repository variable under **Settings → Secrets and variables → Actions → Variables**:
+
+```text
+SERVER_APP_DIR=/absolute/path/to/ChipIn/on/the/server
+```
+
+This is a repository variable, not a secret. Do not put real hostnames, tokens, private keys, or bot secrets in the repo.
+
+### Running a manual deployment
+
+To deploy the latest `main` branch to the server:
+
+1. Open **Actions** in GitHub.
+2. Select **Manual CD**.
+3. Click **Run workflow**.
+
+The workflow runs on the server and executes:
+
+```bash
+cd "$SERVER_APP_DIR"
+git fetch origin
+git checkout main
+git pull --ff-only origin main
+docker compose build app
+docker compose up -d --no-deps app
+```
+
+Only the `app` service is rebuilt and restarted. Redis is not restarted unless you do it manually, and ngrok is not touched.
+
+After deployment, the workflow checks `http://localhost/` and expects the API to report `"status": "running"`. If the health check fails, GitHub Actions prints the app container status and recent app logs before failing the deployment.
+
 ## Getting Started
 
 The fastest way to run the project locally is through Docker Compose:
@@ -149,7 +197,8 @@ This is the main shape of the repo:
 .
 ├── .github/
 │   └── workflows/
-│       └── ci.yml
+│       ├── ci.yml
+│       └── manual-cd.yml
 ├── app/
 │   ├── main.py
 │   ├── models/
@@ -172,6 +221,7 @@ Key areas:
 - [app/static/telegram/](app/static/telegram): Telegram Mini App client served at `/telegram/`
 - [app/tests/](app/tests): route-level tests with a mocked Redis service
 - [.github/workflows/ci.yml](.github/workflows/ci.yml): unit and real Redis Stack integration CI
+- [.github/workflows/manual-cd.yml](.github/workflows/manual-cd.yml): manual deployment through a self-hosted GitHub Actions runner
 
 ## Where To Look First
 

--- a/README.md
+++ b/README.md
@@ -72,15 +72,17 @@ The API currently supports:
 - Redis Stack
 - Docker Compose
 - pytest
+- Playwright
 
 ## Continuous Integration
 
-GitHub Actions runs the workflow in [`.github/workflows/ci.yml`](.github/workflows/ci.yml) on every push and on pull requests targeting `main`. It contains two jobs:
+GitHub Actions runs the workflow in [`.github/workflows/ci.yml`](.github/workflows/ci.yml) on every push and on pull requests targeting `main`. It contains three jobs:
 
 - `test`: installs the Python dependencies and runs the pytest suite with the mocked in-memory Redis service
 - `integration`: validates the Docker Compose configuration, builds and starts the application stack, and exercises the core user, group, expense, lookup, settlement, and deletion flow against a real Redis Stack instance
+- `e2e`: starts a fresh Docker Compose stack and uses Playwright with Chromium to exercise the admin panel and an authenticated Telegram Mini App expense lifecycle through the real browser UI
 
-When both jobs are configured as required status checks in the `main` branch ruleset, GitHub blocks merging until they pass.
+When all three jobs are configured as required status checks in the `main` branch ruleset, GitHub blocks merging until they pass. Failed browser tests upload Playwright traces and screenshots as a short-lived GitHub Actions artifact.
 
 ## Manual CD
 
@@ -206,8 +208,15 @@ This is the main shape of the repo:
 │   ├── services/
 │   ├── static/
 │   └── tests/
+├── e2e/
+│   ├── conftest.py
+│   ├── pytest.ini
+│   ├── requirements.txt
+│   ├── test_admin.py
+│   └── test_telegram.py
 ├── docs/
 ├── Dockerfile
+├── docker-compose.e2e.yml
 └── docker-compose.yml
 ```
 
@@ -220,6 +229,8 @@ Key areas:
 - [app/static/admin/](app/static/admin): admin panel served at `/admin/`
 - [app/static/telegram/](app/static/telegram): Telegram Mini App client served at `/telegram/`
 - [app/tests/](app/tests): route-level tests with a mocked Redis service
+- [e2e/](e2e): Playwright browser tests for the admin panel and Telegram Mini App against the running Compose stack
+- [docker-compose.e2e.yml](docker-compose.e2e.yml): isolated containers, ports, and disposable Redis storage for browser tests
 - [.github/workflows/ci.yml](.github/workflows/ci.yml): unit and real Redis Stack integration CI
 - [.github/workflows/manual-cd.yml](.github/workflows/manual-cd.yml): manual deployment through a self-hosted GitHub Actions runner
 
@@ -238,7 +249,7 @@ If you are visiting the repository for the first time:
 - The Docker setup defines separate `app` and `redis` services in [docker-compose.yml](docker-compose.yml).
 - The admin panel is served by Flask at `/admin/` and calls the existing JSON routes directly.
 - The Telegram Mini App is served by Flask at `/telegram/` and uses Telegram `initData` for user authentication.
-- Tests are written with pytest and use a mocked in-memory Redis service instead of requiring a real Redis instance for test execution.
+- The fast pytest suite uses a mocked in-memory Redis service; the integration and Playwright E2E jobs exercise a real Redis Stack instance through Docker Compose.
 - Some detailed Redis CLI examples in [docs/GET_STARTED_REDIS-STACK.md](docs/GET_STARTED_REDIS-STACK.md) describe the underlying data ideas, but the application code is the source of truth for the current API field names and route behavior.
 
 ## Documentation

--- a/app/tests/test_api_contracts.py
+++ b/app/tests/test_api_contracts.py
@@ -1,0 +1,318 @@
+from datetime import datetime
+from uuid import UUID
+
+
+def assert_iso_datetime(value):
+    assert isinstance(value, str)
+    datetime.fromisoformat(value)
+
+
+def assert_uuid(value):
+    assert isinstance(value, str)
+    UUID(value)
+
+
+def assert_number(value):
+    assert isinstance(value, (int, float))
+    assert not isinstance(value, bool)
+
+
+def assert_user_contract(user, *, name=None, email=None):
+    assert set(user) >= {"id", "name", "email", "created_at"}
+    assert_uuid(user["id"])
+    assert isinstance(user["name"], str)
+    assert isinstance(user["email"], str)
+    assert_iso_datetime(user["created_at"])
+
+    if name is not None:
+        assert user["name"] == name
+    if email is not None:
+        assert user["email"] == email
+
+
+def assert_group_contract(group, *, name=None, users=None):
+    assert set(group) >= {"id", "name", "users", "created_at"}
+    assert_uuid(group["id"])
+    assert isinstance(group["name"], str)
+    assert isinstance(group["users"], list)
+    assert all(isinstance(user_name, str) for user_name in group["users"])
+    assert_iso_datetime(group["created_at"])
+
+    if name is not None:
+        assert group["name"] == name
+    if users is not None:
+        assert group["users"] == users
+
+
+def assert_expense_contract(expense, *, name=None, group=None, payer=None):
+    assert set(expense) >= {
+        "id",
+        "name",
+        "group",
+        "amount",
+        "payer",
+        "sharers",
+    }
+    assert_uuid(expense["id"])
+    assert isinstance(expense["name"], str)
+    assert isinstance(expense["group"], str)
+    assert_number(expense["amount"])
+    assert isinstance(expense["payer"], str)
+    assert isinstance(expense["sharers"], list)
+    assert all(isinstance(sharer, str) for sharer in expense["sharers"])
+
+    if "created_at" in expense:
+        assert_iso_datetime(expense["created_at"])
+    if "group_id" in expense:
+        assert expense["group_id"] is None or isinstance(expense["group_id"], str)
+
+    if name is not None:
+        assert expense["name"] == name
+    if group is not None:
+        assert expense["group"] == group
+    if payer is not None:
+        assert expense["payer"] == payer
+
+
+def assert_settlement_contract(settlements, *, named):
+    assert isinstance(settlements, list)
+
+    for settlement in settlements:
+        assert isinstance(settlement, list)
+        assert len(settlement) == 3
+
+        debtor, creditor, amount = settlement
+        if named:
+            assert isinstance(debtor, str)
+            assert isinstance(creditor, str)
+        else:
+            assert isinstance(debtor, int)
+            assert isinstance(creditor, int)
+        assert_number(amount)
+
+
+def assert_error_contract(response, expected_status):
+    assert response.status_code == expected_status
+    data = response.get_json()
+
+    assert set(data) == {"error"}
+    assert isinstance(data["error"], str)
+    assert data["error"]
+
+
+def create_expense(client, payload):
+    response = client.post("/expenses/", json=payload)
+    assert response.status_code == 201
+    return response.get_json()
+
+
+def test_root_response_contract(client):
+    response = client.get("/")
+
+    assert response.status_code == 200
+    data = response.get_json()
+
+    assert set(data) == {"message", "version", "status", "endpoints"}
+    assert data["message"] == "ChipIn API"
+    assert isinstance(data["version"], str)
+    assert data["status"] == "running"
+    assert data["endpoints"] == {
+        "users": "/users/",
+        "groups": "/groups/",
+        "expenses": "/expenses/",
+        "settlements": "/settlements/",
+        "admin": "/admin/",
+        "telegram_client": "/telegram/",
+        "telegram_webhook": "/telegram/webhook/",
+    }
+
+
+def test_user_and_group_response_contracts(client):
+    alice_response = client.post(
+        "/users/",
+        json={"name": "Alice", "email": "alice@example.com"},
+    )
+    bob_response = client.post(
+        "/users/",
+        json={"name": "Bob", "email": "bob@example.com"},
+    )
+
+    assert alice_response.status_code == 201
+    assert bob_response.status_code == 201
+    alice = alice_response.get_json()
+    bob = bob_response.get_json()
+    assert_user_contract(alice, name="Alice", email="alice@example.com")
+    assert_user_contract(bob, name="Bob", email="bob@example.com")
+
+    users_response = client.get("/users/")
+    assert users_response.status_code == 200
+    users = users_response.get_json()
+    assert isinstance(users, list)
+    assert len(users) == 2
+    for user in users:
+        assert_user_contract(user)
+
+    user_detail_response = client.get(f"/users/{alice['id']}/")
+    assert user_detail_response.status_code == 200
+    assert_user_contract(
+        user_detail_response.get_json(),
+        name="Alice",
+        email="alice@example.com",
+    )
+
+    user_attr_response = client.get(f"/users/{alice['id']}/name/")
+    assert user_attr_response.status_code == 200
+    assert user_attr_response.get_json() == "Alice"
+
+    user_names_response = client.get("/users/user-names/")
+    assert user_names_response.status_code == 200
+    assert user_names_response.get_json() == ["Alice", "Bob"]
+
+    group_response = client.post(
+        "/groups/",
+        json={"name": "Trip", "users": ["Alice", "Bob"]},
+    )
+    assert group_response.status_code == 201
+    group = group_response.get_json()
+    assert_group_contract(group, name="Trip", users=["Alice", "Bob"])
+
+    groups_response = client.get("/groups/")
+    assert groups_response.status_code == 200
+    groups = groups_response.get_json()
+    assert isinstance(groups, list)
+    assert len(groups) == 1
+    assert_group_contract(groups[0], name="Trip", users=["Alice", "Bob"])
+
+    group_detail_response = client.get(f"/groups/{group['id']}/")
+    assert group_detail_response.status_code == 200
+    assert_group_contract(
+        group_detail_response.get_json(),
+        name="Trip",
+        users=["Alice", "Bob"],
+    )
+
+    group_attr_response = client.get(f"/groups/{group['id']}/name/")
+    assert group_attr_response.status_code == 200
+    assert group_attr_response.get_json() == "Trip"
+
+
+def test_expense_and_settlement_response_contracts(client, create_group):
+    group = create_group(name="Trip", users=["Alice", "Bob"])
+    expense_data = create_expense(
+        client,
+        {
+            "name": "Dinner",
+            "group": "Trip",
+            "amount": 30,
+            "payer": "Alice",
+            "sharers": ["Alice", "Bob"],
+        },
+    )
+
+    assert set(expense_data) == {"saved_expense", "group_settlement"}
+    expense = expense_data["saved_expense"]
+    assert_expense_contract(expense, name="Dinner", group="Trip", payer="Alice")
+    assert_settlement_contract(expense_data["group_settlement"], named=False)
+    assert expense_data["group_settlement"] == [[1, 0, 15.0]]
+
+    expense_detail_response = client.get(f"/expenses/{expense['id']}/")
+    assert expense_detail_response.status_code == 200
+    assert_expense_contract(
+        expense_detail_response.get_json(),
+        name="Dinner",
+        group="Trip",
+        payer="Alice",
+    )
+
+    expenses_response = client.get("/expenses/")
+    assert expenses_response.status_code == 200
+    expenses = expenses_response.get_json()
+    assert isinstance(expenses, list)
+    assert len(expenses) == 1
+    assert_expense_contract(expenses[0], name="Dinner", group="Trip", payer="Alice")
+
+    group_expenses_response = client.get(f"/expenses/group/{group['id']}/")
+    assert group_expenses_response.status_code == 200
+    group_expenses = group_expenses_response.get_json()
+    assert isinstance(group_expenses, list)
+    assert len(group_expenses) == 1
+    assert_expense_contract(
+        group_expenses[0],
+        name="Dinner",
+        group="Trip",
+        payer="Alice",
+    )
+    assert "group_id" in group_expenses[0]
+
+    paid_expenses_response = client.get(f"/expenses/user/paid/{group['id']}/")
+    assert paid_expenses_response.status_code == 404
+
+    alice_id = next(
+        user["id"]
+        for user in client.get("/users/").get_json()
+        if user["name"] == "Alice"
+    )
+    paid_expenses_response = client.get(f"/expenses/user/paid/{alice_id}/")
+    assert paid_expenses_response.status_code == 200
+    paid_expenses = paid_expenses_response.get_json()
+    assert isinstance(paid_expenses, list)
+    assert len(paid_expenses) == 1
+    assert_expense_contract(paid_expenses[0], name="Dinner", group="Trip", payer="Alice")
+
+    group_settlement_response = client.get(f"/settlements/group/{group['id']}/")
+    assert group_settlement_response.status_code == 200
+    group_settlement_data = group_settlement_response.get_json()
+    assert set(group_settlement_data) == {"settlements_this_group"}
+    assert_settlement_contract(
+        group_settlement_data["settlements_this_group"],
+        named=True,
+    )
+    assert group_settlement_data["settlements_this_group"] == [["Bob", "Alice", 15.0]]
+
+    all_settlements_response = client.get("/settlements/group/")
+    assert all_settlements_response.status_code == 200
+    all_settlements = all_settlements_response.get_json()
+    assert set(all_settlements) == {f"settlement-group:{group['id']}"}
+    assert_settlement_contract(
+        all_settlements[f"settlement-group:{group['id']}"],
+        named=True,
+    )
+
+
+def test_common_error_response_contracts(client, create_group):
+    create_group(name="Trip", users=["Alice", "Bob"])
+
+    error_cases = [
+        (client.get("/users/not-found/"), 404),
+        (client.get("/groups/not-found/"), 404),
+        (client.get("/expenses/not-found/"), 404),
+        (client.get("/expenses/group/not-found/"), 404),
+        (client.get("/expenses/user/paid/not-found/"), 404),
+        (client.get("/settlements/group/not-found/"), 404),
+        (client.get("/settlements/user/not-found/"), 404),
+        (client.post("/users/", json={"name": "Missing Email"}), 400),
+        (client.post("/groups/", json={"name": "Missing Users"}), 400),
+        (
+            client.post(
+                "/expenses/",
+                json={"name": "Missing Payer", "group": "Trip", "amount": 30},
+            ),
+            400,
+        ),
+        (
+            client.post(
+                "/expenses/",
+                json={
+                    "name": "Bad Sharer",
+                    "group": "Trip",
+                    "amount": 30,
+                    "payer": "Alice",
+                    "sharers": ["Alice", "Charlie"],
+                },
+            ),
+            404,
+        ),
+    ]
+
+    for response, expected_status in error_cases:
+        assert_error_contract(response, expected_status)

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,0 +1,16 @@
+services:
+  redis:
+    container_name: chipin-e2e-redis
+    ports: !override
+      - "16379:6379"
+      - "18001:8001"
+    volumes: !override
+      - e2e-redis-data:/data
+
+  app:
+    container_name: chipin-e2e-app
+    ports: !override
+      - "18080:80"
+
+volumes:
+  e2e-redis-data:

--- a/docs/APP_STRUCTURE.md
+++ b/docs/APP_STRUCTURE.md
@@ -9,7 +9,14 @@ chipin/
 │       ├── ci.yml
 │       └── manual-cd.yml
 ├── docker-compose.yml
+├── docker-compose.e2e.yml
 ├── Dockerfile
+├── e2e/
+│   ├── conftest.py
+│   ├── pytest.ini
+│   ├── requirements.txt
+│   ├── test_admin.py
+│   └── test_telegram.py
 ├── app/
 │   ├── main.py
 │   ├── pytest.ini
@@ -62,13 +69,16 @@ chipin/
 ## What Each Part Does
 
 - `.github/workflows/ci.yml`:
-  Runs the GitHub Actions CI workflow on pushes and pull requests targeting `main`. Its `test` job runs pytest with mocked Redis, while its `integration` job builds the Docker Compose stack and exercises the core API flow against real Redis Stack.
+  Runs the GitHub Actions CI workflow on pushes and pull requests targeting `main`. Its `test` job runs pytest with mocked Redis, its `integration` job exercises the core API flow against real Redis Stack, and its `e2e` job drives the admin and Telegram interfaces in Chromium with Playwright.
 
 - `.github/workflows/manual-cd.yml`:
   Runs the manual deployment workflow on a self-hosted GitHub Actions runner. It updates the server checkout to the latest `main`, rebuilds and restarts only the `app` service, and leaves Redis and ngrok untouched.
 
 - `docker-compose.yml`:
   Runs the Flask app container and the Redis Stack container together.
+
+- `docker-compose.e2e.yml`:
+  Overrides the regular Compose container names, host ports, and Redis storage so browser tests can run beside the normal local stack without touching its data.
 
 - `Dockerfile`:
   Builds the application image and installs Python dependencies.
@@ -120,6 +130,14 @@ chipin/
   - `test_redis_service.py`: focused Redis service helper unit tests
   - `test_settlement_model.py`: settlement calculation unit tests
   - `test_settlements.py`: settlement route tests
+
+- `e2e/`:
+  Browser-level pytest suite powered by Playwright. It starts from the public web interfaces and verifies the JavaScript UI, HTTP API, Flask container, and Redis Stack together.
+  - `conftest.py`: shared application URL and browser-error checks
+  - `test_admin.py`: user, group, expense, settlement, and deletion flow through the admin panel
+  - `test_telegram.py`: signed Telegram Mini App authentication plus expense create, edit, and delete flow
+  - `requirements.txt`: dependencies used only by the E2E test runner
+  - `pytest.ini`: Chromium, trace, screenshot, and pytest settings for the browser suite
 
 - `app/requirements.txt`:
   Python dependencies for the app and tests.

--- a/docs/APP_STRUCTURE.md
+++ b/docs/APP_STRUCTURE.md
@@ -6,7 +6,8 @@ This document reflects the current layout of the ChipIn repo.
 chipin/
 ├── .github/
 │   └── workflows/
-│       └── ci.yml
+│       ├── ci.yml
+│       └── manual-cd.yml
 ├── docker-compose.yml
 ├── Dockerfile
 ├── app/
@@ -41,6 +42,7 @@ chipin/
 │   │       └── styles.css
 │   └── tests/
 │       ├── conftest.py
+│       ├── test_api_contracts.py
 │       ├── test_telegram.py
 │       ├── test_admin.py
 │       ├── test_expenses.py
@@ -61,6 +63,9 @@ chipin/
 
 - `.github/workflows/ci.yml`:
   Runs the GitHub Actions CI workflow on pushes and pull requests targeting `main`. Its `test` job runs pytest with mocked Redis, while its `integration` job builds the Docker Compose stack and exercises the core API flow against real Redis Stack.
+
+- `.github/workflows/manual-cd.yml`:
+  Runs the manual deployment workflow on a self-hosted GitHub Actions runner. It updates the server checkout to the latest `main`, rebuilds and restarts only the `app` service, and leaves Redis and ngrok untouched.
 
 - `docker-compose.yml`:
   Runs the Flask app container and the Redis Stack container together.
@@ -104,6 +109,7 @@ chipin/
 - `app/tests/`:
   Pytest-based route, unit, and static smoke tests. Route tests use a mocked in-memory Redis service so they run quickly without depending on Redis state.
   - `conftest.py`: shared Flask app/client fixtures, helpers, and mock Redis service
+  - `test_api_contracts.py`: API response shape, type, and error contract tests
   - `test_admin.py`: admin panel and static asset smoke tests
   - `test_users.py`: user route tests
   - `test_groups.py`: group route tests

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -158,6 +158,7 @@ Current focused test files:
 
 ```bash
 docker exec chipin-app pytest tests/test_admin.py -v
+docker exec chipin-app pytest tests/test_api_contracts.py -v
 docker exec chipin-app pytest tests/test_expenses.py -v
 docker exec chipin-app pytest tests/test_groups.py -v
 docker exec chipin-app pytest tests/test_main.py -v
@@ -169,7 +170,7 @@ docker exec chipin-app pytest tests/test_telegram.py -v
 docker exec chipin-app pytest tests/test_users.py -v
 ```
 
-Most pytest tests use a mocked in-memory Redis service so they run quickly without depending on Redis state.
+Most pytest tests use a mocked in-memory Redis service so they run quickly without depending on Redis state. The API contract tests focus on keeping public JSON response shapes stable for API clients such as the admin panel and Telegram Mini App.
 
 ## Continuous Integration
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -172,11 +172,48 @@ docker exec chipin-app pytest tests/test_users.py -v
 
 Most pytest tests use a mocked in-memory Redis service so they run quickly without depending on Redis state. The API contract tests focus on keeping public JSON response shapes stable for API clients such as the admin panel and Telegram Mini App.
 
+### Run browser end-to-end tests locally
+
+The Playwright suite drives Chromium through the admin panel and Telegram Mini App. Run it against a local Docker Compose stack, not against the deployment server or data you need to preserve.
+
+```bash
+# From the repository root, create an isolated Python environment
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install -r e2e/requirements.txt
+python -m playwright install chromium
+
+# Use the same dummy Telegram token in the app and the test process
+export TELEGRAM_BOT_TOKEN="123456:e2e-test-token"
+docker compose \
+  -p chipin-e2e \
+  -f docker-compose.yml \
+  -f docker-compose.e2e.yml \
+  up --build -d
+
+# Run Chromium headlessly and retain diagnostics for failures
+cd e2e
+E2E_BASE_URL=http://localhost:18080 python -m pytest --output=test-results
+```
+
+If Chromium reports missing Linux libraries, install them with `python -m playwright install --with-deps chromium`. The E2E Compose override uses ports `18080`, `16379`, and `18001`, plus a separate disposable Redis volume, so the regular ChipIn containers and data remain untouched.
+
+Stop and remove the E2E containers and their disposable Redis volume afterward from the repository root:
+
+```bash
+docker compose \
+  -p chipin-e2e \
+  -f docker-compose.yml \
+  -f docker-compose.e2e.yml \
+  down --volumes
+```
+
 ## Continuous Integration
 
-The GitHub Actions workflow in `.github/workflows/ci.yml` runs on every push and on pull requests targeting `main`. It has two jobs:
+The GitHub Actions workflow in `.github/workflows/ci.yml` runs on every push and on pull requests targeting `main`. It has three jobs:
 
 - `test`: runs the pytest suite with mocked Redis
 - `integration`: builds the Docker Compose stack and tests the core API workflow against real Redis Stack, including users, groups, expenses, RediSearch lookups, settlements, and deletion
+- `e2e`: starts Docker Compose and runs Playwright in Chromium against the admin and authenticated Telegram user interfaces
 
-The integration job always stops the containers and removes their volumes when it finishes.
+The integration and E2E jobs always stop their containers and remove their volumes when they finish. When an E2E test fails, GitHub Actions also uploads its Playwright trace and screenshot for diagnosis.

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -1,0 +1,26 @@
+import os
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def app_url():
+    return os.getenv("E2E_BASE_URL", "http://localhost").rstrip("/")
+
+
+@pytest.fixture(autouse=True)
+def fail_on_browser_errors(page):
+    errors = []
+
+    page.on("pageerror", lambda error: errors.append(f"page error: {error}"))
+    page.on(
+        "console",
+        lambda message: errors.append(f"console error: {message.text}")
+        if message.type == "error"
+        else None,
+    )
+    page.set_default_timeout(10_000)
+
+    yield
+
+    assert not errors, "Browser errors:\n" + "\n".join(errors)

--- a/e2e/pytest.ini
+++ b/e2e/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+testpaths = .
+python_files = test_*.py
+python_functions = test_*
+addopts = -v --tb=short --browser=chromium --tracing=retain-on-failure --screenshot=only-on-failure

--- a/e2e/requirements.txt
+++ b/e2e/requirements.txt
@@ -1,0 +1,3 @@
+playwright==1.61.0
+pytest==9.1.1
+pytest-playwright==0.8.0

--- a/e2e/test_admin.py
+++ b/e2e/test_admin.py
@@ -1,0 +1,64 @@
+from uuid import uuid4
+
+from playwright.sync_api import Page, expect
+
+
+def test_admin_core_expense_flow(page: Page, app_url: str):
+    suffix = uuid4().hex[:8]
+    alice = f"E2E Alice {suffix}"
+    bob = f"E2E Bob {suffix}"
+    group_name = f"E2E Group {suffix}"
+    expense_name = f"E2E Dinner {suffix}"
+
+    page.goto(f"{app_url}/admin/")
+    expect(page.locator("#api-status")).to_have_text("API online")
+
+    _create_user(page, alice, f"alice-{suffix}@example.com")
+    _create_user(page, bob, f"bob-{suffix}@example.com")
+
+    page.locator("#group-name").fill(group_name)
+    page.locator("#group-users label", has_text=alice).locator("input").check()
+    page.locator("#group-users label", has_text=bob).locator("input").check()
+    page.locator("#group-form button[type='submit']").click()
+
+    expect(page.locator("#toast")).to_have_text("Group created")
+    page.get_by_role("tab", name="Groups").click()
+    expect(page.get_by_role("button", name=f"Open {group_name}")).to_be_visible()
+
+    page.locator("#expense-name").fill(expense_name)
+    page.locator("#expense-amount").fill("30")
+    page.locator("#expense-group").select_option(label=group_name)
+    page.locator("#expense-payer").select_option(label=alice)
+    page.locator("#expense-form button[type='submit']").click()
+
+    expect(page.locator("#toast")).to_have_text("Expense added")
+
+    page.get_by_role("tab", name="Expenses").click()
+    expense_row = page.locator("#expenses-table tr", has_text=expense_name)
+    expect(expense_row).to_contain_text(group_name)
+    expect(expense_row).to_contain_text(alice)
+    expect(expense_row).to_contain_text("$30.00")
+
+    page.get_by_role("tab", name="Settlements").click()
+    settlement = page.locator("#settlements-list .settlement-item")
+    expect(settlement).to_contain_text(f"{bob} pays {alice}")
+    expect(settlement).to_contain_text("$15.00")
+
+    page.get_by_role("tab", name="Expenses").click()
+    expense_row.get_by_role("button", name=f"Delete {expense_name}").click()
+    expect(page.locator("#toast")).to_have_text("Expense deleted")
+    expect(page.locator("#expenses-table tr", has_text=expense_name)).to_have_count(0)
+
+    page.get_by_role("tab", name="Groups").click()
+    page.get_by_role("button", name=f"Delete {group_name}").click()
+    expect(page.locator("#toast")).to_have_text("Group deleted")
+    expect(page.get_by_role("button", name=f"Open {group_name}")).to_have_count(0)
+
+
+def _create_user(page: Page, name: str, email: str):
+    page.locator("#user-name").fill(name)
+    page.locator("#user-email").fill(email)
+    page.locator("#user-form button[type='submit']").click()
+
+    expect(page.locator("#toast")).to_have_text("User added")
+    expect(page.locator("#users-table tr", has_text=name)).to_contain_text(email)

--- a/e2e/test_telegram.py
+++ b/e2e/test_telegram.py
@@ -1,0 +1,140 @@
+import hashlib
+import hmac
+import json
+import os
+import time
+from urllib.parse import urlencode
+from uuid import uuid4
+
+from playwright.sync_api import Page, expect
+
+
+DEFAULT_BOT_TOKEN = "123456:e2e-test-token"
+
+
+def test_telegram_expense_lifecycle(page: Page, app_url: str):
+    suffix = uuid4().hex[:8]
+    telegram_user = f"E2E Telegram {suffix}"
+    partner = f"E2E Partner {suffix}"
+    group_name = f"E2E Telegram Group {suffix}"
+    expense_name = f"E2E Coffee {suffix}"
+    updated_expense_name = f"E2E Brunch {suffix}"
+
+    _post_json(
+        page,
+        f"{app_url}/users/",
+        {"name": telegram_user, "email": f"telegram-{suffix}@example.com"},
+    )
+    _post_json(
+        page,
+        f"{app_url}/users/",
+        {"name": partner, "email": f"partner-{suffix}@example.com"},
+    )
+    group = _post_json(
+        page,
+        f"{app_url}/groups/",
+        {"name": group_name, "users": [telegram_user, partner]},
+    )
+
+    telegram_id = int(suffix, 16)
+    init_data = _make_init_data(
+        {
+            "id": telegram_id,
+            "first_name": "E2E Telegram",
+            "last_name": suffix,
+            "username": f"e2e_{suffix}",
+        },
+        os.getenv("TELEGRAM_BOT_TOKEN", DEFAULT_BOT_TOKEN),
+    )
+    _mock_telegram_web_app(page, init_data)
+
+    page.goto(f"{app_url}/telegram/?group_id={group['id']}")
+
+    expect(page.locator("#dashboard")).to_be_visible()
+    expect(page.locator("#user-pill")).to_have_text(telegram_user)
+    expect(page.locator("#groups-list")).to_contain_text(group_name)
+    expect(page.locator("#group-detail")).to_be_visible()
+    expect(page.locator("#group-detail h2")).to_have_text(group_name)
+
+    detail = page.locator("#group-detail")
+    detail.locator("#expense-name").fill(expense_name)
+    detail.locator("#expense-amount").fill("24")
+    detail.get_by_role("button", name="Add Expense").click()
+
+    expect(page.locator("#toast")).to_have_text("Expense added")
+    expense_row = detail.locator(".row", has_text=expense_name)
+    expect(expense_row).to_contain_text("$24.00")
+    expect(expense_row).to_contain_text(telegram_user)
+    settlement_row = detail.locator(".row", has_text=f"{partner} to {telegram_user}")
+    expect(settlement_row).to_contain_text("$12.00")
+
+    expense_row.get_by_role("button", name="Edit").click()
+    detail.locator("#expense-name").fill(updated_expense_name)
+    detail.locator("#expense-amount").fill("30")
+    detail.get_by_role("button", name="Save Expense").click()
+
+    expect(page.locator("#toast")).to_have_text("Expense updated")
+    updated_row = detail.locator(".row", has_text=updated_expense_name)
+    expect(updated_row).to_contain_text("$30.00")
+    expect(detail.locator(".row", has_text=f"{partner} to {telegram_user}")).to_contain_text(
+        "$15.00"
+    )
+
+    page.once("dialog", lambda dialog: dialog.accept())
+    updated_row.get_by_role("button", name="Delete").click()
+
+    expect(page.locator("#toast")).to_have_text("Expense deleted")
+    expect(detail.locator(".row", has_text=updated_expense_name)).to_have_count(0)
+    expect(detail.locator(".list", has_text="No expenses")).to_be_visible()
+
+
+def _post_json(page: Page, url: str, payload: dict):
+    response = page.request.post(url, data=payload)
+    assert response.status == 201, f"POST {url} failed: {response.status} {response.text()}"
+    return response.json()
+
+
+def _make_init_data(user: dict, bot_token: str):
+    fields = {
+        "auth_date": str(int(time.time())),
+        "user": json.dumps(user, separators=(",", ":")),
+    }
+    data_check_string = "\n".join(
+        f"{key}={value}" for key, value in sorted(fields.items())
+    )
+    secret_key = hmac.new(
+        b"WebAppData",
+        bot_token.encode("utf-8"),
+        hashlib.sha256,
+    ).digest()
+    fields["hash"] = hmac.new(
+        secret_key,
+        data_check_string.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    return urlencode(fields)
+
+
+def _mock_telegram_web_app(page: Page, init_data: str):
+    script = f"""
+      window.Telegram = {{
+        WebApp: {{
+          initData: {json.dumps(init_data)},
+          ready() {{}},
+          expand() {{}},
+          openTelegramLink() {{}},
+          HapticFeedback: {{
+            notificationOccurred() {{}},
+            selectionChanged() {{}},
+          }},
+        }},
+      }};
+    """
+    page.route(
+        "https://telegram.org/js/telegram-web-app.js",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/javascript",
+            body=script,
+        ),
+    )


### PR DESCRIPTION
1. Expands Docker and Redis integration smoke testing.
2. Adds API contract tests.
3. Adds isolated Playwright E2E tests for the admin panel and Telegram Mini App.
4. Adds manual deployment through a self-hosted GitHub Actions runner.
5. Updates documentation and runner-related ignore rules.